### PR TITLE
Expand calculator with Credit-to-Cash and Personal Loan types, fix bugs, and improve UI

### DIFF
--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -1,7 +1,9 @@
-import { calculateInstallmentOption, suggestPrincipalBinarySearch } from "@/lib/server";
+import { calculateInstallmentOption } from "@/lib/server";
+import { DST_EXEMPTION_THRESHOLD, DST_RATE_PER_200 } from "@/constant";
 import { NextRequest, NextResponse } from "next/server";
 
 interface InstallmentRequest {
+  calculatorType: string;
   amount: number;
   installmentAmount: number;
   interestRate: number;
@@ -13,6 +15,7 @@ interface InstallmentRequest {
 
 export async function POST(request: NextRequest) {
   const {
+    calculatorType,
     amount,
     installmentAmount,
     interestRate,
@@ -22,8 +25,17 @@ export async function POST(request: NextRequest) {
     installmentPlanList,
   } = (await request.json()) as InstallmentRequest;
 
+  // Calculate DST for personal loans (₱1.50 per ₱200, exempt if ≤ ₱250K)
+  const dst =
+    calculatorType === "personal-loan" && amount > DST_EXEMPTION_THRESHOLD
+      ? Math.ceil(amount / 200) * DST_RATE_PER_200
+      : 0;
+
+  const totalFees = (processingFee || 0) + dst;
+  const netProceeds = amount - totalFees;
+
   const allInstallmentPlans = installmentPlanList.map((installment) =>
-    calculateInstallmentOption(amount, installmentAmount, interestRate, +installment, processingFee)
+    calculateInstallmentOption(amount, installmentAmount, interestRate, +installment, totalFees)
   );
 
   const selectedInstallmentPlan = allInstallmentPlans.find((plan) => plan.months === +numInstallments);
@@ -34,5 +46,8 @@ export async function POST(request: NextRequest) {
     selected: selectedInstallmentPlan,
     others: otherInstallmentPlans,
     monthlyBudget,
+    calculatorType,
+    dst,
+    netProceeds,
   });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,71 +1,71 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
- 
+
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --foreground: 222.2 84% 4.9%;
 
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
- 
-    --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
- 
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
- 
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
- 
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
- 
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
- 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
+    --card-foreground: 222.2 84% 4.9%;
 
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
- 
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+
+    --primary: 221.2 83.2% 53.3%;
+    --primary-foreground: 210 40% 98%;
+
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 221.2 83.2% 53.3%;
+
     --radius: 0.5rem;
   }
- 
+
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
- 
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
- 
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
- 
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
- 
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
- 
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
- 
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
- 
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
- 
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 224.3 76.3% 48%;
   }
 }
- 
+
 @layer base {
   * {
     @apply border-border;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Inter as FontSans } from "next/font/google";
 import { cn } from "@/lib/utils";
 import { ThemeProvider } from "@/components/theme-provider";
 import Navbar from "@/components/navbar";
+import Footer from "@/components/footer";
 
 const fontSans = FontSans({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -65,6 +66,7 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <Navbar />
           {children}
+          <Footer />
           <Toaster position="top-center" richColors />
         </ThemeProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,12 +3,14 @@
 import { CALCULATOR_CONFIG } from "@/constant";
 import { AllInstallmentOption, PaymentDifferences } from "@/interfaces";
 import { CalculateForm } from "@/schema";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { toast } from "sonner";
 
 import CardInstallmentForm from "@/components/installment/card-form";
 import CardSelectedPlan from "@/components/installment/selected-plan";
 import OtherPlanTable from "@/components/installment/other-plan-table";
+import CostBreakdown from "@/components/installment/cost-breakdown";
+import AmortizationSchedule from "@/components/installment/amortization-schedule";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { CheckCircledIcon } from "@radix-ui/react-icons";
 import type { CalculatorType } from "@/constant";
@@ -17,8 +19,11 @@ export default function Home() {
   const [calculatedData, setCalculatedData] = useState<AllInstallmentOption>();
   const [paymentDifferences, setPaymentDifferences] = useState<PaymentDifferences>();
   const [hasCalculated, setHasCalculated] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [formValues, setFormValues] = useState<{ amount: number; monthlyRate: number }>({ amount: 0, monthlyRate: 0 });
 
-  const calculateInstallmentData = async (values: CalculateForm) => {
+  const calculateInstallmentData = useCallback(async (values: CalculateForm) => {
+    setIsLoading(true);
     try {
       const calculatorType = (values.calculatorType ?? "balance-conversion") as CalculatorType;
       const config = CALCULATOR_CONFIG[calculatorType];
@@ -42,11 +47,18 @@ export default function Home() {
         totalInstallmentWithZeroPercent: installmentAmount > 0 ? installmentAmount : undefined,
       });
 
+      setFormValues({
+        amount: values.amount,
+        monthlyRate: values.interestRate / 100,
+      });
+
       setHasCalculated(true);
     } catch (error) {
       toast.error("Error fetching data");
+    } finally {
+      setIsLoading(false);
     }
-  };
+  }, []);
 
   const onSubmit = (values: CalculateForm) => {
     calculateInstallmentData(values);
@@ -54,7 +66,7 @@ export default function Home() {
 
   return (
     <main className="items-center justify-between p-4 space-y-4">
-      {hasCalculated && (
+      {hasCalculated && !isLoading && (
         <Alert className="border-green-200 text-green-800 bg-green-50 dark:border-green-200 dark:bg-green-100 dark:text-green-800 [&>svg]:text-green-800">
           <CheckCircledIcon className="h-4 w-4" />
           <AlertTitle>Ready to Explore Your Options</AlertTitle>
@@ -66,13 +78,27 @@ export default function Home() {
       )}
 
       {/* Installment Form */}
-      <CardInstallmentForm onSubmit={onSubmit} />
+      <CardInstallmentForm onSubmit={onSubmit} isLoading={isLoading} />
 
       {/* Selected Installment Plan and Difference */}
-      <CardSelectedPlan calculatedData={calculatedData} paymentDifferences={paymentDifferences} />
+      <CardSelectedPlan calculatedData={calculatedData} paymentDifferences={paymentDifferences} isLoading={isLoading} />
+
+      {/* Cost Breakdown */}
+      {(hasCalculated || isLoading) && (
+        <CostBreakdown calculatedData={calculatedData} amount={formValues.amount} />
+      )}
 
       {/* Table of Other Installment Plan */}
-      <OtherPlanTable calculatedData={calculatedData} budget={calculatedData?.monthlyBudget} />
+      <OtherPlanTable calculatedData={calculatedData} budget={calculatedData?.monthlyBudget} isLoading={isLoading} />
+
+      {/* Amortization Schedule */}
+      {hasCalculated && (
+        <AmortizationSchedule
+          selected={calculatedData?.selected}
+          principal={formValues.amount}
+          monthlyRate={formValues.monthlyRate}
+        />
+      )}
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { INSTALLMENT_PLAN_LIST } from "@/constant";
+import { CALCULATOR_CONFIG } from "@/constant";
 import { AllInstallmentOption, PaymentDifferences } from "@/interfaces";
 import { CalculateForm } from "@/schema";
 import { useState } from "react";
@@ -11,19 +11,21 @@ import CardSelectedPlan from "@/components/installment/selected-plan";
 import OtherPlanTable from "@/components/installment/other-plan-table";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { CheckCircledIcon } from "@radix-ui/react-icons";
+import type { CalculatorType } from "@/constant";
 
 export default function Home() {
   const [calculatedData, setCalculatedData] = useState<AllInstallmentOption>();
   const [paymentDifferences, setPaymentDifferences] = useState<PaymentDifferences>();
-  const [isLoading, setIsLoading] = useState(true);
+  const [hasCalculated, setHasCalculated] = useState(false);
 
   const calculateInstallmentData = async (values: CalculateForm) => {
-    setIsLoading(true);
-
     try {
+      const calculatorType = (values.calculatorType ?? "balance-conversion") as CalculatorType;
+      const config = CALCULATOR_CONFIG[calculatorType];
+
       const response = await fetch("/api", {
         method: "POST",
-        body: JSON.stringify({ ...values, installmentPlanList: INSTALLMENT_PLAN_LIST }),
+        body: JSON.stringify({ ...values, installmentPlanList: config.installmentPlans }),
       });
 
       if (!response.ok) {
@@ -32,15 +34,17 @@ export default function Home() {
 
       const res = await response.json();
       setCalculatedData(res);
+
+      const installmentAmount = values.installmentAmount ?? 0;
       setPaymentDifferences({
         totalFullPayment: values.amount,
         totalInstallmentWithInterest: +res.selected.totalPayment,
-        totalInstallmentWithZeroPercent: values.installmentAmount,
+        totalInstallmentWithZeroPercent: installmentAmount > 0 ? installmentAmount : undefined,
       });
+
+      setHasCalculated(true);
     } catch (error) {
       toast.error("Error fetching data");
-    } finally {
-      setIsLoading(false);
     }
   };
 
@@ -50,7 +54,7 @@ export default function Home() {
 
   return (
     <main className="items-center justify-between p-4 space-y-4">
-      {!isLoading && (
+      {hasCalculated && (
         <Alert className="border-green-200 text-green-800 bg-green-50 dark:border-green-200 dark:bg-green-100 dark:text-green-800 [&>svg]:text-green-800">
           <CheckCircledIcon className="h-4 w-4" />
           <AlertTitle>Ready to Explore Your Options</AlertTitle>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+
+const Footer: React.FC = () => {
+  return (
+    <footer className="border-t mt-8">
+      <div className="container mx-auto px-4 py-6">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 text-sm">
+          {/* About */}
+          <div>
+            <h3 className="font-semibold mb-2">Savvy Spender</h3>
+            <p className="text-muted-foreground text-xs">
+              A free financial calculator for Philippine bank installment products. Compare balance conversions,
+              credit-to-cash, and personal loan options.
+            </p>
+          </div>
+
+          {/* Quick Links */}
+          <div>
+            <h3 className="font-semibold mb-2">Quick Links</h3>
+            <ul className="space-y-1 text-xs">
+              <li>
+                <Link href="/" className="text-muted-foreground hover:text-foreground transition-colors">
+                  Calculator
+                </Link>
+              </li>
+              <li>
+                <Link href="/docs" className="text-muted-foreground hover:text-foreground transition-colors">
+                  Documentation
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/bank-conversion-list"
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Bank Conversion List
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          {/* Disclaimer */}
+          <div>
+            <h3 className="font-semibold mb-2">Disclaimer</h3>
+            <p className="text-muted-foreground text-xs">
+              This tool is for reference only. Rates and terms vary by bank and may change. Always verify with your bank
+              before making financial decisions.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 pt-4 border-t text-center text-xs text-muted-foreground">
+          <p>
+            Built with care for Filipino consumers.{" "}
+            <Link
+              href="https://github.com/Kevin-Umali/savvy-spender"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors underline"
+            >
+              Open Source on GitHub
+            </Link>
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/components/installment/amortization-schedule.tsx
+++ b/components/installment/amortization-schedule.tsx
@@ -1,0 +1,110 @@
+import { useState, useMemo } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { formatCurrency } from "@/lib/client";
+import { InstallmentOption } from "@/interfaces";
+import { ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons";
+
+interface AmortizationScheduleProps {
+  selected: InstallmentOption | undefined;
+  principal: number;
+  monthlyRate: number;
+}
+
+interface AmortizationRow {
+  month: number;
+  payment: number;
+  principalPortion: number;
+  interestPortion: number;
+  remainingBalance: number;
+  totalPaidSoFar: number;
+}
+
+const AmortizationSchedule: React.FC<AmortizationScheduleProps> = ({ selected, principal, monthlyRate }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const schedule = useMemo(() => {
+    if (!selected) return [];
+
+    const months = +selected.months;
+    const monthlyPayment = +selected.monthlyPayment;
+    const interestPerMonth = principal * monthlyRate;
+    const principalPerMonth = monthlyPayment - interestPerMonth;
+
+    const rows: AmortizationRow[] = [];
+    let remainingBalance = principal;
+
+    for (let i = 1; i <= months; i++) {
+      remainingBalance = Math.max(0, remainingBalance - principalPerMonth);
+      rows.push({
+        month: i,
+        payment: monthlyPayment,
+        principalPortion: principalPerMonth,
+        interestPortion: interestPerMonth,
+        remainingBalance: i === months ? 0 : remainingBalance,
+        totalPaidSoFar: monthlyPayment * i,
+      });
+    }
+
+    return rows;
+  }, [selected, principal, monthlyRate]);
+
+  if (!selected || schedule.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader className="cursor-pointer" onClick={() => setIsExpanded(!isExpanded)}>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Amortization Schedule</CardTitle>
+            <CardDescription>Month-by-month payment breakdown for {+selected.months} months.</CardDescription>
+          </div>
+          <Button variant="ghost" size="sm">
+            {isExpanded ? <ChevronUpIcon className="h-5 w-5" /> : <ChevronDownIcon className="h-5 w-5" />}
+          </Button>
+        </div>
+      </CardHeader>
+
+      {isExpanded && (
+        <CardContent>
+          <p className="text-xs text-muted-foreground mb-3">
+            Using the add-on (flat) rate method, both the principal and interest portions are constant each month. The
+            bank charges interest on the original full principal for every month — your balance does not &quot;diminish&quot; for
+            interest calculation purposes.
+          </p>
+          <div className="overflow-x-auto -mx-6 px-6">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-16">Month</TableHead>
+                  <TableHead>Payment</TableHead>
+                  <TableHead>Principal</TableHead>
+                  <TableHead>Interest</TableHead>
+                  <TableHead>Balance</TableHead>
+                  <TableHead>Total Paid</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {schedule.map((row) => (
+                  <TableRow key={row.month}>
+                    <TableCell className="font-medium">{row.month}</TableCell>
+                    <TableCell>{formatCurrency(row.payment)}</TableCell>
+                    <TableCell>{formatCurrency(row.principalPortion)}</TableCell>
+                    <TableCell className="text-orange-600 dark:text-orange-400">
+                      {formatCurrency(row.interestPortion)}
+                    </TableCell>
+                    <TableCell>{formatCurrency(row.remainingBalance)}</TableCell>
+                    <TableCell className="text-muted-foreground">{formatCurrency(row.totalPaidSoFar)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+};
+
+export default AmortizationSchedule;

--- a/components/installment/card-form.tsx
+++ b/components/installment/card-form.tsx
@@ -7,16 +7,31 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { CalculateForm, CalculateFormSchema } from "@/schema";
 import { CALCULATOR_TYPES, CALCULATOR_CONFIG, DST_EXEMPTION_THRESHOLD, DST_RATE_PER_200 } from "@/constant";
 import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/client";
+import { InfoCircledIcon, ReloadIcon, UpdateIcon } from "@radix-ui/react-icons";
 import type { CalculatorType } from "@/constant";
 
 interface CardInstallmentFormProps {
   onSubmit: (values: CalculateForm) => void;
+  isLoading?: boolean;
 }
 
-const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit }) => {
+const InfoTip: React.FC<{ content: string }> = ({ content }) => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <InfoCircledIcon className="ml-1.5 h-3.5 w-3.5 inline-block text-muted-foreground cursor-help" />
+    </TooltipTrigger>
+    <TooltipContent side="top" className="max-w-[300px] text-xs font-normal">
+      <p>{content}</p>
+    </TooltipContent>
+  </Tooltip>
+);
+
+const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit, isLoading = false }) => {
   const form = useForm<CalculateForm>({
     resolver: zodResolver(CalculateFormSchema),
     defaultValues: {
@@ -36,7 +51,6 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit }) =
 
   const config = CALCULATOR_CONFIG[calculatorType];
 
-  // Estimate DST for preview in the form
   const estimatedDST = useMemo(() => {
     if (calculatorType !== "personal-loan" || !amount || amount <= DST_EXEMPTION_THRESHOLD) return 0;
     return Math.ceil(amount / 200) * DST_RATE_PER_200;
@@ -47,227 +61,280 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit }) =
     return amount - estimatedDST - processingFee;
   }, [calculatorType, amount, estimatedDST, processingFee]);
 
-  // When calculator type changes, update defaults
   useEffect(() => {
     const currentPlan = form.getValues("numInstallments");
     if (!config.installmentPlans.includes(currentPlan)) {
       form.setValue("numInstallments", config.installmentPlans[0] as CalculateForm["numInstallments"]);
     }
-    // Reset installmentAmount to 0 when not applicable
     if (!config.showInstallmentAmount) {
       form.setValue("installmentAmount", 0);
     }
   }, [calculatorType, config, form]);
 
+  const handleReset = () => {
+    form.reset({
+      calculatorType: "balance-conversion",
+      amount: 10000,
+      interestRate: 0.99,
+      numInstallments: "3",
+      processingFee: 0,
+      installmentAmount: 0,
+      monthlyBudget: 0,
+    });
+  };
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Calculate Your Installment Plan</CardTitle>
-        <CardDescription>
-          Select a calculator type and enter your details to compare installment options.
-        </CardDescription>
-      </CardHeader>
+    <TooltipProvider delayDuration={200}>
+      <Card>
+        <CardHeader>
+          <CardTitle>Calculate Your Installment Plan</CardTitle>
+          <CardDescription>
+            Select a calculator type and enter your details to compare installment options across different terms.
+          </CardDescription>
+        </CardHeader>
 
-      <CardContent>
-        {/* Calculator Type Selector */}
-        <div className="mb-6">
-          <Label className="mb-2 block text-sm font-medium">Calculator Type</Label>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-            {CALCULATOR_TYPES.map((type) => (
-              <button
-                key={type.value}
-                type="button"
-                className={cn(
-                  "rounded-lg border-2 px-4 py-3 text-left transition-all",
-                  calculatorType === type.value
-                    ? "border-primary bg-primary/5 shadow-sm"
-                    : "border-border hover:border-primary/40 hover:bg-muted/50"
-                )}
-                onClick={() => form.setValue("calculatorType", type.value)}
-              >
-                <span className="block text-sm font-semibold">{type.label}</span>
-                <span className="block text-xs text-muted-foreground mt-0.5">{type.description}</span>
-              </button>
-            ))}
-          </div>
-        </div>
+        <CardContent>
+          {/* Calculator Type Selector */}
+          <fieldset disabled={isLoading} className="mb-6">
+            <Label className="mb-2 block text-sm font-medium">
+              Calculator Type
+              <InfoTip content="Choose the type of financial product you want to calculate. Each type has different fees, fields, and terms." />
+            </Label>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {CALCULATOR_TYPES.map((type) => (
+                <button
+                  key={type.value}
+                  type="button"
+                  disabled={isLoading}
+                  className={cn(
+                    "rounded-lg border-2 px-4 py-3 text-left transition-all disabled:opacity-60",
+                    calculatorType === type.value
+                      ? "border-primary bg-primary/5 shadow-sm"
+                      : "border-border hover:border-primary/40 hover:bg-muted/50"
+                  )}
+                  onClick={() => form.setValue("calculatorType", type.value)}
+                >
+                  <span className="block text-sm font-semibold">{type.label}</span>
+                  <span className="block text-xs text-muted-foreground mt-0.5">{type.description}</span>
+                </button>
+              ))}
+            </div>
+          </fieldset>
 
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            {/* Principal/Amount Field */}
-            <FormField
-              name="amount"
-              control={form.control}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{config.amountLabel}</FormLabel>
-                  <FormControl>
-                    <Input type="number" placeholder={config.amountPlaceholder} {...field} />
-                  </FormControl>
-                  <FormDescription>{config.amountDescription}</FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {/* Interest Rate Field */}
-            <FormField
-              name="interestRate"
-              control={form.control}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Monthly Add-On Interest Rate (%)</FormLabel>
-                  <FormControl>
-                    <Input type="number" step="0.01" placeholder="Enter monthly interest rate (e.g., 0.99)" {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    The monthly add-on (flat) rate applied to the original principal each month. BSP caps this at 1% per
-                    month for credit card installments.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {/* Number of Installments Field */}
-            <FormField
-              name="numInstallments"
-              control={form.control}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Number of Installments (Months)</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select installment term" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {config.installmentPlans.map((num) => (
-                        <SelectItem key={num} value={num}>
-                          {num} months
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormDescription>
-                    Choose how many months to spread your payments over.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {/* Processing Fee Field */}
-              <FormField
-                name="processingFee"
-                control={form.control}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      {config.processingFeeLabel}
-                      <Label className="ml-2 text-gray-500 text-xs">(Optional)</Label>
-                    </FormLabel>
-                    <FormControl>
-                      <Input type="number" placeholder={config.processingFeePlaceholder} {...field} />
-                    </FormControl>
-                    <FormDescription>{config.processingFeeDescription}</FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Installment Amount Field - only for Balance Conversion */}
-              {config.showInstallmentAmount && (
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <fieldset disabled={isLoading} className="space-y-4">
+                {/* Amount Field */}
                 <FormField
-                  name="installmentAmount"
+                  name="amount"
                   control={form.control}
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>
-                        0% Installment Amount
-                        <Label className="ml-2 text-gray-500 text-xs">(Optional)</Label>
+                        {config.amountLabel}
+                        <InfoTip
+                          content={
+                            calculatorType === "balance-conversion"
+                              ? "Enter the full cash price of the item you purchased. This is the amount that will be converted into bank installments with interest."
+                              : calculatorType === "credit-to-cash"
+                                ? "Enter the amount you want to convert from your unused credit limit into cash. This will be deposited to your bank account."
+                                : "Enter the total loan amount you want to borrow. Note: DST and fees will be deducted, so your actual proceeds will be lower."
+                          }
+                        />
                       </FormLabel>
                       <FormControl>
-                        <Input type="number" placeholder="Enter 0% installment amount" {...field} />
+                        <Input type="number" placeholder={config.amountPlaceholder} {...field} />
+                      </FormControl>
+                      <FormDescription>{config.amountDescription}</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Interest Rate Field */}
+                <FormField
+                  name="interestRate"
+                  control={form.control}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        Monthly Add-On Interest Rate (%)
+                        <InfoTip content="This is the monthly add-on (flat) rate. In the Philippines, interest is charged on the ORIGINAL principal every month, not on the declining balance. The BSP caps this at 1% per month for credit card installments. The true cost (EIR) is roughly 1.8x–2.0x this rate." />
+                      </FormLabel>
+                      <FormControl>
+                        <Input type="number" step="0.01" placeholder="Enter monthly interest rate (e.g., 0.99)" {...field} />
                       </FormControl>
                       <FormDescription>
-                        The total amount if paying via 0% interest installment plan. Used to compare and suggest an
-                        optimal principal.
+                        Add-on (flat) rate applied to the original principal.
+                        {calculatorType === "personal-loan"
+                          ? " Typical PH personal loan rates: 1.20%–1.79%/month."
+                          : " BSP caps credit card installments at 1%/month."}
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
-              )}
 
-              {/* Monthly Budget Field */}
-              <FormField
-                name="monthlyBudget"
-                control={form.control}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      Monthly Budget
-                      <Label className="ml-2 text-gray-500 text-xs">(Optional)</Label>
-                    </FormLabel>
-                    <FormControl>
-                      <Input type="number" placeholder="Enter monthly budget" {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      Your monthly budget for payments. Plans within budget will be highlighted in green.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+                {/* Number of Installments */}
+                <FormField
+                  name="numInstallments"
+                  control={form.control}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        Number of Installments (Months)
+                        <InfoTip content="Choose how many months to spread your payments. Longer terms mean lower monthly payments but higher total interest. The calculator will also show all other terms for comparison." />
+                      </FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select installment term" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {config.installmentPlans.map((num) => (
+                            <SelectItem key={num} value={num}>
+                              {num} months
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        The calculator will also show all other available terms for comparison.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-            {/* DST & Net Proceeds Preview for Personal Loans */}
-            {config.showDST && amount > 0 && (
-              <div className="rounded-lg border bg-muted/30 p-4 space-y-2">
-                <Label className="text-sm font-semibold">Loan Fee Breakdown (Estimate)</Label>
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
-                  <div>
-                    <span className="text-muted-foreground">Documentary Stamp Tax:</span>
-                    <span className="ml-2 font-medium">
-                      {estimatedDST > 0
-                        ? `₱${estimatedDST.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-                        : "Exempt (≤ ₱250K)"}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-muted-foreground">Processing Fee:</span>
-                    <span className="ml-2 font-medium">
-                      ₱{(processingFee || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-muted-foreground">Est. Net Proceeds:</span>
-                    <span className="ml-2 font-semibold text-primary">
-                      ₱{estimatedNetProceeds.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                    </span>
-                  </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {/* Processing Fee */}
+                  <FormField
+                    name="processingFee"
+                    control={form.control}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          {config.processingFeeLabel}
+                          <Label className="ml-1 text-gray-500 text-xs">(Optional)</Label>
+                          <InfoTip
+                            content={
+                              calculatorType === "personal-loan"
+                                ? "Banks charge an origination or disbursement fee deducted from your loan proceeds. Typical: ₱1,300–₱1,500."
+                                : "A one-time fee charged by the bank for the conversion, added to your balance. Typical: ₱250–₱500."
+                            }
+                          />
+                        </FormLabel>
+                        <FormControl>
+                          <Input type="number" placeholder={config.processingFeePlaceholder} {...field} />
+                        </FormControl>
+                        <FormDescription>{config.processingFeeDescription}</FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Installment Amount - Balance Conversion only */}
+                  {config.showInstallmentAmount && (
+                    <FormField
+                      name="installmentAmount"
+                      control={form.control}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>
+                            0% Installment Amount
+                            <Label className="ml-1 text-gray-500 text-xs">(Optional)</Label>
+                            <InfoTip content="If the merchant offers a 0% interest installment plan, enter the TOTAL price under that plan here. It may be higher than the cash price. The calculator will compare this against bank conversion and suggest the best option." />
+                          </FormLabel>
+                          <FormControl>
+                            <Input type="number" placeholder="Enter 0% installment total price" {...field} />
+                          </FormControl>
+                          <FormDescription>
+                            Total price under the merchant&apos;s 0% plan for comparison.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  )}
+
+                  {/* Monthly Budget */}
+                  <FormField
+                    name="monthlyBudget"
+                    control={form.control}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          Monthly Budget
+                          <Label className="ml-1 text-gray-500 text-xs">(Optional)</Label>
+                          <InfoTip content="Enter the maximum amount you can comfortably pay each month. Plans within budget will be highlighted green; plans exceeding it will be red." />
+                        </FormLabel>
+                        <FormControl>
+                          <Input type="number" placeholder="Enter monthly budget" {...field} />
+                        </FormControl>
+                        <FormDescription>Plans within budget will be highlighted green.</FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
                 </div>
-                <p className="text-xs text-muted-foreground">
-                  DST is ₱1.50 per ₱200 of loan amount (~0.75%). Loans ≤ ₱250,000 for personal use are exempt per NIRC.
-                </p>
-              </div>
-            )}
 
-            <Button className="mx-auto w-full" type="submit">
-              Calculate
-            </Button>
-          </form>
-        </Form>
-        <Label className="mt-4 block text-xs text-muted-foreground">
-          NOTE: Different banks may offer varying conversion terms and rates. The information provided here is for
-          reference purposes only. It is advisable to verify the details directly with the respective banks. Interest
-          rates shown are add-on (flat) rates — the effective interest rate (EIR) will be higher.
-        </Label>
-      </CardContent>
-    </Card>
+                {/* DST Preview for Personal Loans */}
+                {config.showDST && amount > 0 && (
+                  <div className="rounded-lg border bg-muted/30 p-4 space-y-2">
+                    <Label className="text-sm font-semibold">
+                      Loan Fee Breakdown (Estimate)
+                      <InfoTip content="These fees are deducted from your loan amount before disbursement. You receive the net proceeds but pay interest on the full loan amount." />
+                    </Label>
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+                      <div>
+                        <span className="text-muted-foreground">Documentary Stamp Tax:</span>
+                        <span className="ml-2 font-medium">
+                          {estimatedDST > 0 ? formatCurrency(estimatedDST) : "Exempt (≤ ₱250K)"}
+                        </span>
+                      </div>
+                      <div>
+                        <span className="text-muted-foreground">Processing Fee:</span>
+                        <span className="ml-2 font-medium">{formatCurrency(processingFee || 0)}</span>
+                      </div>
+                      <div>
+                        <span className="text-muted-foreground">Est. Net Proceeds:</span>
+                        <span className="ml-2 font-semibold text-primary">{formatCurrency(estimatedNetProceeds)}</span>
+                      </div>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      DST is ₱1.50 per ₱200 of loan amount (~0.75%). Loans ≤ ₱250,000 are exempt per NIRC.
+                    </p>
+                  </div>
+                )}
+              </fieldset>
+
+              {/* Action Buttons */}
+              <div className="flex gap-3">
+                <Button className="flex-1" type="submit" disabled={isLoading}>
+                  {isLoading ? (
+                    <>
+                      <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                      Calculating...
+                    </>
+                  ) : (
+                    "Calculate"
+                  )}
+                </Button>
+                <Button type="button" variant="outline" onClick={handleReset} disabled={isLoading}>
+                  <ReloadIcon className="mr-2 h-4 w-4" />
+                  Reset
+                </Button>
+              </div>
+            </form>
+          </Form>
+          <p className="mt-4 text-xs text-muted-foreground">
+            Different banks offer varying terms and rates. This calculator is for reference only — verify details
+            directly with your bank. Interest rates shown are add-on (flat) rates; the effective rate (EIR) is higher.
+          </p>
+        </CardContent>
+      </Card>
+    </TooltipProvider>
   );
 };
 

--- a/components/installment/card-form.tsx
+++ b/components/installment/card-form.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "@/components/ui/input";
@@ -7,6 +8,9 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { CalculateForm, CalculateFormSchema } from "@/schema";
+import { CALCULATOR_TYPES, CALCULATOR_CONFIG, DST_EXEMPTION_THRESHOLD, DST_RATE_PER_200 } from "@/constant";
+import { cn } from "@/lib/utils";
+import type { CalculatorType } from "@/constant";
 
 interface CardInstallmentFormProps {
   onSubmit: (values: CalculateForm) => void;
@@ -16,8 +20,9 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit }) =
   const form = useForm<CalculateForm>({
     resolver: zodResolver(CalculateFormSchema),
     defaultValues: {
+      calculatorType: "balance-conversion",
       amount: 10000,
-      interestRate: 1,
+      interestRate: 0.99,
       numInstallments: "3",
       processingFee: 0,
       installmentAmount: 0,
@@ -25,16 +30,68 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit }) =
     },
   });
 
+  const calculatorType = form.watch("calculatorType") as CalculatorType;
+  const amount = form.watch("amount");
+  const processingFee = form.watch("processingFee") ?? 0;
+
+  const config = CALCULATOR_CONFIG[calculatorType];
+
+  // Estimate DST for preview in the form
+  const estimatedDST = useMemo(() => {
+    if (calculatorType !== "personal-loan" || !amount || amount <= DST_EXEMPTION_THRESHOLD) return 0;
+    return Math.ceil(amount / 200) * DST_RATE_PER_200;
+  }, [calculatorType, amount]);
+
+  const estimatedNetProceeds = useMemo(() => {
+    if (calculatorType !== "personal-loan" || !amount) return 0;
+    return amount - estimatedDST - processingFee;
+  }, [calculatorType, amount, estimatedDST, processingFee]);
+
+  // When calculator type changes, update defaults
+  useEffect(() => {
+    const currentPlan = form.getValues("numInstallments");
+    if (!config.installmentPlans.includes(currentPlan)) {
+      form.setValue("numInstallments", config.installmentPlans[0] as CalculateForm["numInstallments"]);
+    }
+    // Reset installmentAmount to 0 when not applicable
+    if (!config.showInstallmentAmount) {
+      form.setValue("installmentAmount", 0);
+    }
+  }, [calculatorType, config, form]);
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Calculate Your Installment Plan</CardTitle>
         <CardDescription>
-          Enter your desired loan amount, interest rate, and other details to view various installment options.
+          Select a calculator type and enter your details to compare installment options.
         </CardDescription>
       </CardHeader>
 
       <CardContent>
+        {/* Calculator Type Selector */}
+        <div className="mb-6">
+          <Label className="mb-2 block text-sm font-medium">Calculator Type</Label>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            {CALCULATOR_TYPES.map((type) => (
+              <button
+                key={type.value}
+                type="button"
+                className={cn(
+                  "rounded-lg border-2 px-4 py-3 text-left transition-all",
+                  calculatorType === type.value
+                    ? "border-primary bg-primary/5 shadow-sm"
+                    : "border-border hover:border-primary/40 hover:bg-muted/50"
+                )}
+                onClick={() => form.setValue("calculatorType", type.value)}
+              >
+                <span className="block text-sm font-semibold">{type.label}</span>
+                <span className="block text-xs text-muted-foreground mt-0.5">{type.description}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             {/* Principal/Amount Field */}
@@ -43,14 +100,11 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit }) =
               control={form.control}
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Principal / Amount</FormLabel>
+                  <FormLabel>{config.amountLabel}</FormLabel>
                   <FormControl>
-                    <Input type="number" placeholder="Enter principal or amount of the items" {...field} />
+                    <Input type="number" placeholder={config.amountPlaceholder} {...field} />
                   </FormControl>
-                  <FormDescription>
-                    This is for the full cash price of the item or the total amount, which will then be converted into
-                    banking installments.
-                  </FormDescription>
+                  <FormDescription>{config.amountDescription}</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -62,12 +116,13 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit }) =
               control={form.control}
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Interest Rate</FormLabel>
+                  <FormLabel>Monthly Add-On Interest Rate (%)</FormLabel>
                   <FormControl>
-                    <Input type="number" step="0.01" placeholder="Enter interest rate" {...field} />
+                    <Input type="number" step="0.01" placeholder="Enter monthly interest rate (e.g., 0.99)" {...field} />
                   </FormControl>
                   <FormDescription>
-                    This is for entering the interest rate that will be applied to your purchase, if applicable.
+                    The monthly add-on (flat) rate applied to the original principal each month. BSP caps this at 1% per
+                    month for credit card installments.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -80,24 +135,23 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit }) =
               control={form.control}
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Number of Installments</FormLabel>
-                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                  <FormLabel>Number of Installments (Months)</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
                     <FormControl>
                       <SelectTrigger>
-                        <SelectValue placeholder="Select a installment plan" />
+                        <SelectValue placeholder="Select installment term" />
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {["3", "6", "9", "12", "15", "18", "21", "24", "27", "30", "33", "36"].map((num) => (
+                      {config.installmentPlans.map((num) => (
                         <SelectItem key={num} value={num}>
-                          {num}
+                          {num} months
                         </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
                   <FormDescription>
-                    This is for selecting the number of installments for your payment plan. Your choice will determine
-                    how many times you make payments
+                    Choose how many months to spread your payments over.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -112,42 +166,41 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit }) =
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>
-                      Processing Fee
+                      {config.processingFeeLabel}
                       <Label className="ml-2 text-gray-500 text-xs">(Optional)</Label>
                     </FormLabel>
                     <FormControl>
-                      <Input type="number" placeholder="Enter processing fee" {...field} />
+                      <Input type="number" placeholder={config.processingFeePlaceholder} {...field} />
                     </FormControl>
-                    <FormDescription>
-                      This is for specifying any associated processing fee for your installment, which may apply to your
-                      transaction
-                    </FormDescription>
+                    <FormDescription>{config.processingFeeDescription}</FormDescription>
                     <FormMessage />
                   </FormItem>
                 )}
               />
 
-              {/* Installment Amount Field */}
-              <FormField
-                name="installmentAmount"
-                control={form.control}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      Installment Amount
-                      <Label className="ml-2 text-gray-500 text-xs">(Optional)</Label>
-                    </FormLabel>
-                    <FormControl>
-                      <Input type="number" placeholder="Enter installment amount of the items" {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      This is for specifying the installment amount for your purchase, usually with a 0% interest rate.
-                      Note that the installment amount is distinct from the principal/total amount.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              {/* Installment Amount Field - only for Balance Conversion */}
+              {config.showInstallmentAmount && (
+                <FormField
+                  name="installmentAmount"
+                  control={form.control}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        0% Installment Amount
+                        <Label className="ml-2 text-gray-500 text-xs">(Optional)</Label>
+                      </FormLabel>
+                      <FormControl>
+                        <Input type="number" placeholder="Enter 0% installment amount" {...field} />
+                      </FormControl>
+                      <FormDescription>
+                        The total amount if paying via 0% interest installment plan. Used to compare and suggest an
+                        optimal principal.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
 
               {/* Monthly Budget Field */}
               <FormField
@@ -160,24 +213,58 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit }) =
                       <Label className="ml-2 text-gray-500 text-xs">(Optional)</Label>
                     </FormLabel>
                     <FormControl>
-                      <Input type="number" placeholder="Enter processing fee" {...field} />
+                      <Input type="number" placeholder="Enter monthly budget" {...field} />
                     </FormControl>
-                    <FormDescription>This is for how much you can pay on a monthly basis.</FormDescription>
+                    <FormDescription>
+                      Your monthly budget for payments. Plans within budget will be highlighted in green.
+                    </FormDescription>
                     <FormMessage />
                   </FormItem>
                 )}
               />
             </div>
 
+            {/* DST & Net Proceeds Preview for Personal Loans */}
+            {config.showDST && amount > 0 && (
+              <div className="rounded-lg border bg-muted/30 p-4 space-y-2">
+                <Label className="text-sm font-semibold">Loan Fee Breakdown (Estimate)</Label>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+                  <div>
+                    <span className="text-muted-foreground">Documentary Stamp Tax:</span>
+                    <span className="ml-2 font-medium">
+                      {estimatedDST > 0
+                        ? `₱${estimatedDST.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+                        : "Exempt (≤ ₱250K)"}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Processing Fee:</span>
+                    <span className="ml-2 font-medium">
+                      ₱{(processingFee || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Est. Net Proceeds:</span>
+                    <span className="ml-2 font-semibold text-primary">
+                      ₱{estimatedNetProceeds.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </span>
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  DST is ₱1.50 per ₱200 of loan amount (~0.75%). Loans ≤ ₱250,000 for personal use are exempt per NIRC.
+                </p>
+              </div>
+            )}
+
             <Button className="mx-auto w-full" type="submit">
               Calculate
             </Button>
           </form>
         </Form>
-        <Label className="font-semibold">
-          NOTE: Different banks may offer varying conversion terms and rates. Please note that the information provided
-          here is for reference purposes only and may not be entirely accurate. It is intended to give you an idea of
-          potential installment amounts, but it is advisable to verify the details directly with the respective banks.
+        <Label className="mt-4 block text-xs text-muted-foreground">
+          NOTE: Different banks may offer varying conversion terms and rates. The information provided here is for
+          reference purposes only. It is advisable to verify the details directly with the respective banks. Interest
+          rates shown are add-on (flat) rates — the effective interest rate (EIR) will be higher.
         </Label>
       </CardContent>
     </Card>

--- a/components/installment/cost-breakdown.tsx
+++ b/components/installment/cost-breakdown.tsx
@@ -1,0 +1,116 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { formatCurrency } from "@/lib/client";
+import { AllInstallmentOption } from "@/interfaces";
+
+interface CostBreakdownProps {
+  calculatedData: AllInstallmentOption | undefined;
+  amount: number;
+}
+
+const CostBreakdown: React.FC<CostBreakdownProps> = ({ calculatedData, amount }) => {
+  if (!calculatedData?.selected) return null;
+
+  const principal = amount;
+  const interest = +calculatedData.selected.interest;
+  const totalFees = (calculatedData.dst ?? 0) + (calculatedData.selected.processingFee ? +calculatedData.selected.processingFee : 0);
+  const totalPayment = +calculatedData.selected.totalPayment;
+
+  const interestPercent = principal > 0 ? ((interest / principal) * 100).toFixed(1) : "0";
+  const feesPercent = principal > 0 ? ((totalFees / principal) * 100).toFixed(1) : "0";
+
+  const principalWidth = totalPayment > 0 ? (principal / totalPayment) * 100 : 0;
+  const interestWidth = totalPayment > 0 ? (interest / totalPayment) * 100 : 0;
+  const feesWidth = totalPayment > 0 ? (totalFees / totalPayment) * 100 : 0;
+
+  const isPersonalLoan = calculatedData.calculatorType === "personal-loan";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Cost Breakdown</CardTitle>
+        <CardDescription>
+          See exactly where your money goes — principal, interest, and fees.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Visual bar */}
+        <div className="space-y-2">
+          <div className="flex rounded-full overflow-hidden h-4">
+            <div
+              className="bg-primary transition-all"
+              style={{ width: `${principalWidth}%` }}
+              title={`Principal: ${formatCurrency(principal)}`}
+            />
+            <div
+              className="bg-orange-400 dark:bg-orange-500 transition-all"
+              style={{ width: `${interestWidth}%` }}
+              title={`Interest: ${formatCurrency(interest)}`}
+            />
+            {feesWidth > 0 && (
+              <div
+                className="bg-red-400 dark:bg-red-500 transition-all"
+                style={{ width: `${feesWidth}%` }}
+                title={`Fees: ${formatCurrency(totalFees)}`}
+              />
+            )}
+          </div>
+          <div className="flex flex-wrap gap-4 text-xs">
+            <div className="flex items-center gap-1.5">
+              <div className="h-3 w-3 rounded-full bg-primary" />
+              <span>Principal</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <div className="h-3 w-3 rounded-full bg-orange-400 dark:bg-orange-500" />
+              <span>Interest</span>
+            </div>
+            {totalFees > 0 && (
+              <div className="flex items-center gap-1.5">
+                <div className="h-3 w-3 rounded-full bg-red-400 dark:bg-red-500" />
+                <span>Fees</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Details */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div className="rounded-lg border p-3">
+            <Label className="text-xs text-muted-foreground">Principal</Label>
+            <p className="text-lg font-semibold">{formatCurrency(principal)}</p>
+          </div>
+          <div className="rounded-lg border p-3">
+            <Label className="text-xs text-muted-foreground">Total Interest ({interestPercent}% of principal)</Label>
+            <p className="text-lg font-semibold text-orange-600 dark:text-orange-400">{formatCurrency(interest)}</p>
+          </div>
+          {totalFees > 0 && (
+            <div className="rounded-lg border p-3">
+              <Label className="text-xs text-muted-foreground">
+                Fees ({feesPercent}% of principal)
+                {isPersonalLoan && calculatedData.dst ? ` — incl. DST ${formatCurrency(calculatedData.dst)}` : ""}
+              </Label>
+              <p className="text-lg font-semibold text-red-600 dark:text-red-400">{formatCurrency(totalFees)}</p>
+            </div>
+          )}
+          <div className="rounded-lg border border-primary/30 bg-primary/5 p-3">
+            <Label className="text-xs text-muted-foreground">Total Amount Payable</Label>
+            <p className="text-lg font-bold text-primary">{formatCurrency(totalPayment)}</p>
+          </div>
+        </div>
+
+        {/* Net proceeds for personal loan */}
+        {isPersonalLoan && calculatedData.netProceeds !== undefined && (
+          <div className="rounded-lg border border-dashed p-3 text-center">
+            <Label className="text-xs text-muted-foreground">You receive (Net Proceeds)</Label>
+            <p className="text-xl font-bold text-primary">{formatCurrency(calculatedData.netProceeds)}</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              But you pay back {formatCurrency(totalPayment)} — that&apos;s {formatCurrency(totalPayment - calculatedData.netProceeds)} more than you received.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CostBreakdown;

--- a/components/installment/other-plan-table.tsx
+++ b/components/installment/other-plan-table.tsx
@@ -1,13 +1,19 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { AllInstallmentOption } from "@/interfaces";
+import { formatCurrency, formatPercent } from "@/lib/client";
 
 interface OtherPlanTableProps {
   calculatedData: AllInstallmentOption | undefined;
   budget?: number;
+  isLoading?: boolean;
 }
 
-const OtherPlanTable: React.FC<OtherPlanTableProps> = ({ calculatedData, budget = 0 }) => {
+const Skeleton: React.FC<{ className?: string }> = ({ className = "" }) => (
+  <div className={`animate-pulse bg-muted rounded ${className}`} />
+);
+
+const OtherPlanTable: React.FC<OtherPlanTableProps> = ({ calculatedData, budget = 0, isLoading = false }) => {
   const hasBudget = budget > 0;
   const isBalanceConversion = calculatedData?.calculatorType === "balance-conversion";
 
@@ -18,53 +24,67 @@ const OtherPlanTable: React.FC<OtherPlanTableProps> = ({ calculatedData, budget 
         <CardDescription>Compare all available installment terms side by side.</CardDescription>
       </CardHeader>
 
-      {calculatedData?.others && (
+      {isLoading ? (
         <CardContent>
-          <Table>
-            <TableCaption>A list of other installment plans</TableCaption>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Months</TableHead>
-                <TableHead>Simple Interest</TableHead>
-                <TableHead>Factor Rate</TableHead>
-                <TableHead>EIR PA</TableHead>
-                <TableHead>Monthly Payment</TableHead>
-                <TableHead>Interest</TableHead>
-                <TableHead>Total Payment w/ Fees</TableHead>
-                {isBalanceConversion && <TableHead>Suggested Principal / Total</TableHead>}
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {calculatedData.others.map((installment) => (
-                <TableRow key={installment.months}>
-                  <TableCell>{installment.months}</TableCell>
-                  <TableCell>{installment.simpleInterest}%</TableCell>
-                  <TableCell>{installment.factorRate}</TableCell>
-                  <TableCell>{installment.eirPA}%</TableCell>
-                  <TableCell
-                    className={
-                      hasBudget
-                        ? +installment.monthlyPayment <= budget
-                          ? "bg-green-100 dark:bg-green-800"
-                          : "bg-red-100 dark:bg-red-800"
-                        : ""
-                    }
-                  >
-                    ₱{installment.monthlyPayment}
-                  </TableCell>
-                  <TableCell>₱{installment.interest}</TableCell>
-                  <TableCell>₱{installment.totalPayment}</TableCell>
-                  {isBalanceConversion && (
-                    <TableCell>
-                      ₱{installment.suggestedPrincipal.suggested} / ₱{installment.suggestedPrincipal.totalPayment}
-                    </TableCell>
-                  )}
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          <div className="space-y-3">
+            <Skeleton className="h-8 w-full" />
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
         </CardContent>
-      )}
+      ) : calculatedData?.others ? (
+        <CardContent>
+          <div className="overflow-x-auto -mx-6 px-6">
+            <Table>
+              <TableCaption>All other available installment terms</TableCaption>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Months</TableHead>
+                  <TableHead>Simple Interest</TableHead>
+                  <TableHead>Factor Rate</TableHead>
+                  <TableHead>EIR PA</TableHead>
+                  <TableHead>Monthly Payment</TableHead>
+                  <TableHead>Interest</TableHead>
+                  <TableHead>Total w/ Fees</TableHead>
+                  {isBalanceConversion && <TableHead>Suggested Principal / Total</TableHead>}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {calculatedData.others.map((installment) => (
+                  <TableRow key={installment.months}>
+                    <TableCell className="font-medium">{installment.months}</TableCell>
+                    <TableCell>{formatPercent(installment.simpleInterest)}</TableCell>
+                    <TableCell>{installment.factorRate}</TableCell>
+                    <TableCell>{formatPercent(installment.eirPA)}</TableCell>
+                    <TableCell
+                      className={
+                        hasBudget
+                          ? +installment.monthlyPayment <= budget
+                            ? "text-green-600 dark:text-green-400 font-medium"
+                            : "text-red-600 dark:text-red-400 font-medium"
+                          : ""
+                      }
+                    >
+                      {formatCurrency(installment.monthlyPayment)}
+                    </TableCell>
+                    <TableCell className="text-orange-600 dark:text-orange-400">
+                      {formatCurrency(installment.interest)}
+                    </TableCell>
+                    <TableCell className="font-semibold">{formatCurrency(installment.totalPayment)}</TableCell>
+                    {isBalanceConversion && (
+                      <TableCell>
+                        {formatCurrency(installment.suggestedPrincipal.suggested)} /{" "}
+                        {formatCurrency(installment.suggestedPrincipal.totalPayment)}
+                      </TableCell>
+                    )}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      ) : null}
     </Card>
   );
 };

--- a/components/installment/other-plan-table.tsx
+++ b/components/installment/other-plan-table.tsx
@@ -8,11 +8,14 @@ interface OtherPlanTableProps {
 }
 
 const OtherPlanTable: React.FC<OtherPlanTableProps> = ({ calculatedData, budget = 0 }) => {
+  const hasBudget = budget > 0;
+  const isBalanceConversion = calculatedData?.calculatorType === "balance-conversion";
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Other Installment Plan</CardTitle>
-        <CardDescription>Details of the installment of other plan.</CardDescription>
+        <CardTitle>Other Installment Plans</CardTitle>
+        <CardDescription>Compare all available installment terms side by side.</CardDescription>
       </CardHeader>
 
       {calculatedData?.others && (
@@ -27,8 +30,8 @@ const OtherPlanTable: React.FC<OtherPlanTableProps> = ({ calculatedData, budget 
                 <TableHead>EIR PA</TableHead>
                 <TableHead>Monthly Payment</TableHead>
                 <TableHead>Interest</TableHead>
-                <TableHead>Total Payment w/PF</TableHead>
-                <TableHead>Suggested Principal / Total Payment</TableHead>
+                <TableHead>Total Payment w/ Fees</TableHead>
+                {isBalanceConversion && <TableHead>Suggested Principal / Total</TableHead>}
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -40,18 +43,22 @@ const OtherPlanTable: React.FC<OtherPlanTableProps> = ({ calculatedData, budget 
                   <TableCell>{installment.eirPA}%</TableCell>
                   <TableCell
                     className={
-                      +installment.monthlyPayment <= budget
-                        ? "bg-green-100 dark:bg-green-800"
-                        : "bg-red-100 dark:bg-red-800"
+                      hasBudget
+                        ? +installment.monthlyPayment <= budget
+                          ? "bg-green-100 dark:bg-green-800"
+                          : "bg-red-100 dark:bg-red-800"
+                        : ""
                     }
                   >
                     ₱{installment.monthlyPayment}
                   </TableCell>
                   <TableCell>₱{installment.interest}</TableCell>
                   <TableCell>₱{installment.totalPayment}</TableCell>
-                  <TableCell>
-                    ₱{installment.suggestedPrincipal.suggested} / ₱{installment.suggestedPrincipal.totalPayment}
-                  </TableCell>
+                  {isBalanceConversion && (
+                    <TableCell>
+                      ₱{installment.suggestedPrincipal.suggested} / ₱{installment.suggestedPrincipal.totalPayment}
+                    </TableCell>
+                  )}
                 </TableRow>
               ))}
             </TableBody>

--- a/components/installment/selected-plan.tsx
+++ b/components/installment/selected-plan.tsx
@@ -8,6 +8,10 @@ interface CardSelectedPlanProps {
 }
 
 const CardSelectedPlan: React.FC<CardSelectedPlanProps> = ({ calculatedData, paymentDifferences }) => {
+  const hasBudget = (calculatedData?.monthlyBudget ?? 0) > 0;
+  const isBalanceConversion = calculatedData?.calculatorType === "balance-conversion";
+  const isPersonalLoan = calculatedData?.calculatorType === "personal-loan";
+
   return (
     <Card>
       <CardHeader>
@@ -38,9 +42,11 @@ const CardSelectedPlan: React.FC<CardSelectedPlanProps> = ({ calculatedData, pay
               <Label className="font-semibold">Monthly Payment:</Label>
               <Label
                 className={`ml-2 ${
-                  +calculatedData.selected.monthlyPayment <= (calculatedData?.monthlyBudget ?? 0)
-                    ? "bg-green-100 dark:bg-green-800"
-                    : "bg-red-100 dark:bg-red-800"
+                  hasBudget
+                    ? +calculatedData.selected.monthlyPayment <= (calculatedData?.monthlyBudget ?? 0)
+                      ? "bg-green-100 dark:bg-green-800"
+                      : "bg-red-100 dark:bg-red-800"
+                    : ""
                 } `}
               >
                 ₱{calculatedData.selected.monthlyPayment}
@@ -52,13 +58,47 @@ const CardSelectedPlan: React.FC<CardSelectedPlanProps> = ({ calculatedData, pay
             </div>
             <div>
               <Label className="font-semibold">Total Payment:</Label>
-              <Label className="ml-2">₱{calculatedData.selected.totalPayment} w/ processing fee</Label>
+              <Label className="ml-2">₱{calculatedData.selected.totalPayment} w/ fees</Label>
             </div>
           </div>
         </CardContent>
       )}
 
-      {calculatedData?.selected?.suggestedPrincipal && (
+      {/* DST & Net Proceeds for Personal Loans */}
+      {isPersonalLoan && calculatedData?.dst !== undefined && (
+        <>
+          <CardHeader>
+            <CardTitle>Loan Disbursement Details</CardTitle>
+            <CardDescription>
+              Fees deducted from your loan amount before disbursement.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              <div>
+                <Label className="font-semibold">Documentary Stamp Tax:</Label>
+                <Label className="ml-2">
+                  {calculatedData.dst > 0
+                    ? `₱${calculatedData.dst.toLocaleString()}`
+                    : "Exempt (≤ ₱250K)"}
+                </Label>
+              </div>
+              {calculatedData.netProceeds !== undefined && (
+                <div>
+                  <Label className="font-semibold">Estimated Net Proceeds:</Label>
+                  <Label className="ml-2 font-semibold text-primary">
+                    ₱{calculatedData.netProceeds.toLocaleString()}
+                  </Label>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </>
+      )}
+
+      {/* Suggested Principal - only for Balance Conversion with installmentAmount > 0 */}
+      {isBalanceConversion && calculatedData?.selected?.suggestedPrincipal &&
+        +calculatedData.selected.suggestedPrincipal.suggested > 0 && (
         <>
           <CardHeader>
             <CardTitle>Optimal Principal Insight</CardTitle>
@@ -87,22 +127,26 @@ const CardSelectedPlan: React.FC<CardSelectedPlanProps> = ({ calculatedData, pay
       )}
 
       <CardHeader>
-        <CardTitle>Payment Comparison</CardTitle>
-        <CardDescription>See how different payment methods compare.</CardDescription>
+        <CardTitle>Payment Summary</CardTitle>
+        <CardDescription>Compare your payment amounts at a glance.</CardDescription>
       </CardHeader>
 
       {paymentDifferences && (
         <CardContent>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             <div>
-              <Label className="font-semibold">Total Full Payment:</Label>
+              <Label className="font-semibold">
+                {isPersonalLoan ? "Loan Amount:" : "Total Full Payment:"}
+              </Label>
               <Label className="ml-2">₱{paymentDifferences.totalFullPayment.toLocaleString()}</Label>
             </div>
             <div>
-              <Label className="font-semibold">Total Installment With Interest:</Label>
+              <Label className="font-semibold">Total With Interest + Fees:</Label>
               <Label className="ml-2">₱{paymentDifferences.totalInstallmentWithInterest.toLocaleString()}</Label>
             </div>
-            {paymentDifferences.totalInstallmentWithZeroPercent !== undefined && (
+            {isBalanceConversion &&
+              paymentDifferences.totalInstallmentWithZeroPercent !== undefined &&
+              paymentDifferences.totalInstallmentWithZeroPercent > 0 && (
               <div>
                 <Label className="font-semibold">Total Installment With 0% Interest:</Label>
                 <Label className="ml-2">₱{paymentDifferences.totalInstallmentWithZeroPercent.toLocaleString()}</Label>

--- a/components/installment/selected-plan.tsx
+++ b/components/installment/selected-plan.tsx
@@ -1,13 +1,19 @@
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { AllInstallmentOption, PaymentDifferences } from "@/interfaces";
+import { formatCurrency, formatPercent } from "@/lib/client";
 
 interface CardSelectedPlanProps {
   calculatedData: AllInstallmentOption | undefined;
   paymentDifferences: PaymentDifferences | undefined;
+  isLoading?: boolean;
 }
 
-const CardSelectedPlan: React.FC<CardSelectedPlanProps> = ({ calculatedData, paymentDifferences }) => {
+const Skeleton: React.FC<{ className?: string }> = ({ className = "" }) => (
+  <div className={`animate-pulse bg-muted rounded ${className}`} />
+);
+
+const CardSelectedPlan: React.FC<CardSelectedPlanProps> = ({ calculatedData, paymentDifferences, isLoading = false }) => {
   const hasBudget = (calculatedData?.monthlyBudget ?? 0) > 0;
   const isBalanceConversion = calculatedData?.calculatorType === "balance-conversion";
   const isPersonalLoan = calculatedData?.calculatorType === "personal-loan";
@@ -19,76 +25,90 @@ const CardSelectedPlan: React.FC<CardSelectedPlanProps> = ({ calculatedData, pay
         <CardDescription>Details of the installment plan you selected.</CardDescription>
       </CardHeader>
 
-      {calculatedData?.selected && (
+      {isLoading ? (
+        <CardContent>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {Array.from({ length: 7 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-5 w-32" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      ) : calculatedData?.selected ? (
         <CardContent>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             <div>
-              <Label className="font-semibold">Months:</Label>
-              <Label className="ml-2">{calculatedData.selected.months}</Label>
+              <Label className="text-xs text-muted-foreground">Months</Label>
+              <p className="text-sm font-semibold">{calculatedData.selected.months}</p>
             </div>
             <div>
-              <Label className="font-semibold">Simple Interest:</Label>
-              <Label className="ml-2">{calculatedData.selected.simpleInterest}%</Label>
+              <Label className="text-xs text-muted-foreground">Simple Interest</Label>
+              <p className="text-sm font-semibold">{formatPercent(calculatedData.selected.simpleInterest)}</p>
             </div>
             <div>
-              <Label className="font-semibold">Factor Rate:</Label>
-              <Label className="ml-2">{calculatedData.selected.factorRate}</Label>
+              <Label className="text-xs text-muted-foreground">Factor Rate</Label>
+              <p className="text-sm font-semibold">{calculatedData.selected.factorRate}</p>
             </div>
             <div>
-              <Label className="font-semibold">Effective Interest Rate PA:</Label>
-              <Label className="ml-2">{calculatedData.selected.eirPA}%</Label>
+              <Label className="text-xs text-muted-foreground">Effective Interest Rate PA</Label>
+              <p className="text-sm font-semibold">{formatPercent(calculatedData.selected.eirPA)}</p>
             </div>
             <div>
-              <Label className="font-semibold">Monthly Payment:</Label>
-              <Label
-                className={`ml-2 ${
+              <Label className="text-xs text-muted-foreground">Monthly Payment</Label>
+              <p
+                className={`text-sm font-semibold ${
                   hasBudget
                     ? +calculatedData.selected.monthlyPayment <= (calculatedData?.monthlyBudget ?? 0)
-                      ? "bg-green-100 dark:bg-green-800"
-                      : "bg-red-100 dark:bg-red-800"
+                      ? "text-green-600 dark:text-green-400"
+                      : "text-red-600 dark:text-red-400"
                     : ""
-                } `}
+                }`}
               >
-                ₱{calculatedData.selected.monthlyPayment}
-              </Label>
+                {formatCurrency(calculatedData.selected.monthlyPayment)}
+                {hasBudget && (
+                  <span className="text-xs font-normal ml-1">
+                    {+calculatedData.selected.monthlyPayment <= (calculatedData?.monthlyBudget ?? 0)
+                      ? "(within budget)"
+                      : "(exceeds budget)"}
+                  </span>
+                )}
+              </p>
             </div>
             <div>
-              <Label className="font-semibold">Interest:</Label>
-              <Label className="ml-2">₱{calculatedData.selected.interest}</Label>
+              <Label className="text-xs text-muted-foreground">Total Interest</Label>
+              <p className="text-sm font-semibold text-orange-600 dark:text-orange-400">
+                {formatCurrency(calculatedData.selected.interest)}
+              </p>
             </div>
             <div>
-              <Label className="font-semibold">Total Payment:</Label>
-              <Label className="ml-2">₱{calculatedData.selected.totalPayment} w/ fees</Label>
+              <Label className="text-xs text-muted-foreground">Total Payment (w/ fees)</Label>
+              <p className="text-sm font-bold text-primary">{formatCurrency(calculatedData.selected.totalPayment)}</p>
             </div>
           </div>
         </CardContent>
-      )}
+      ) : null}
 
       {/* DST & Net Proceeds for Personal Loans */}
-      {isPersonalLoan && calculatedData?.dst !== undefined && (
+      {!isLoading && isPersonalLoan && calculatedData?.dst !== undefined && (
         <>
           <CardHeader>
             <CardTitle>Loan Disbursement Details</CardTitle>
-            <CardDescription>
-              Fees deducted from your loan amount before disbursement.
-            </CardDescription>
+            <CardDescription>Fees deducted from your loan amount before disbursement.</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               <div>
-                <Label className="font-semibold">Documentary Stamp Tax:</Label>
-                <Label className="ml-2">
-                  {calculatedData.dst > 0
-                    ? `₱${calculatedData.dst.toLocaleString()}`
-                    : "Exempt (≤ ₱250K)"}
-                </Label>
+                <Label className="text-xs text-muted-foreground">Documentary Stamp Tax</Label>
+                <p className="text-sm font-semibold">
+                  {calculatedData.dst > 0 ? formatCurrency(calculatedData.dst) : "Exempt (≤ ₱250K)"}
+                </p>
               </div>
               {calculatedData.netProceeds !== undefined && (
                 <div>
-                  <Label className="font-semibold">Estimated Net Proceeds:</Label>
-                  <Label className="ml-2 font-semibold text-primary">
-                    ₱{calculatedData.netProceeds.toLocaleString()}
-                  </Label>
+                  <Label className="text-xs text-muted-foreground">Estimated Net Proceeds</Label>
+                  <p className="text-sm font-bold text-primary">{formatCurrency(calculatedData.netProceeds)}</p>
                 </div>
               )}
             </div>
@@ -96,64 +116,71 @@ const CardSelectedPlan: React.FC<CardSelectedPlanProps> = ({ calculatedData, pay
         </>
       )}
 
-      {/* Suggested Principal - only for Balance Conversion with installmentAmount > 0 */}
-      {isBalanceConversion && calculatedData?.selected?.suggestedPrincipal &&
+      {/* Suggested Principal - Balance Conversion only */}
+      {!isLoading &&
+        isBalanceConversion &&
+        calculatedData?.selected?.suggestedPrincipal &&
         +calculatedData.selected.suggestedPrincipal.suggested > 0 && (
+          <>
+            <CardHeader>
+              <CardTitle>Optimal Principal Insight</CardTitle>
+              <CardDescription>
+                The ideal principal to keep your total installment just under the 0% interest threshold.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                <div>
+                  <Label className="text-xs text-muted-foreground">Suggested Principal</Label>
+                  <p className="text-sm font-semibold">
+                    {formatCurrency(calculatedData.selected.suggestedPrincipal.suggested)}
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-xs text-muted-foreground">Total With Interest</Label>
+                  <p className="text-sm font-semibold">
+                    {formatCurrency(calculatedData.selected.suggestedPrincipal.totalPayment)}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </>
+        )}
+
+      {/* Payment Summary */}
+      {!isLoading && paymentDifferences && (
         <>
           <CardHeader>
-            <CardTitle>Optimal Principal Insight</CardTitle>
-            <CardDescription>
-              Discover the ideal principal to keep your total installment just under the 0% interest threshold.
-            </CardDescription>
+            <CardTitle>Payment Summary</CardTitle>
+            <CardDescription>Compare your payment amounts at a glance.</CardDescription>
           </CardHeader>
-
           <CardContent>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               <div>
-                <Label className="font-semibold">Suggested Principal:</Label>
-                <Label className="ml-2">
-                  ₱{calculatedData?.selected?.suggestedPrincipal.suggested.toLocaleString()}
+                <Label className="text-xs text-muted-foreground">
+                  {isPersonalLoan ? "Loan Amount" : "Cash Price (Full Payment)"}
                 </Label>
+                <p className="text-sm font-semibold">{formatCurrency(paymentDifferences.totalFullPayment)}</p>
               </div>
               <div>
-                <Label className="font-semibold">Total Installment With Interest:</Label>
-                <Label className="ml-2">
-                  ₱{calculatedData?.selected?.suggestedPrincipal.totalPayment.toLocaleString()}
-                </Label>
+                <Label className="text-xs text-muted-foreground">Total With Interest + Fees</Label>
+                <p className="text-sm font-bold text-primary">
+                  {formatCurrency(paymentDifferences.totalInstallmentWithInterest)}
+                </p>
               </div>
+              {isBalanceConversion &&
+                paymentDifferences.totalInstallmentWithZeroPercent !== undefined &&
+                paymentDifferences.totalInstallmentWithZeroPercent > 0 && (
+                  <div>
+                    <Label className="text-xs text-muted-foreground">0% Merchant Installment</Label>
+                    <p className="text-sm font-semibold">
+                      {formatCurrency(paymentDifferences.totalInstallmentWithZeroPercent)}
+                    </p>
+                  </div>
+                )}
             </div>
           </CardContent>
         </>
-      )}
-
-      <CardHeader>
-        <CardTitle>Payment Summary</CardTitle>
-        <CardDescription>Compare your payment amounts at a glance.</CardDescription>
-      </CardHeader>
-
-      {paymentDifferences && (
-        <CardContent>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <div>
-              <Label className="font-semibold">
-                {isPersonalLoan ? "Loan Amount:" : "Total Full Payment:"}
-              </Label>
-              <Label className="ml-2">₱{paymentDifferences.totalFullPayment.toLocaleString()}</Label>
-            </div>
-            <div>
-              <Label className="font-semibold">Total With Interest + Fees:</Label>
-              <Label className="ml-2">₱{paymentDifferences.totalInstallmentWithInterest.toLocaleString()}</Label>
-            </div>
-            {isBalanceConversion &&
-              paymentDifferences.totalInstallmentWithZeroPercent !== undefined &&
-              paymentDifferences.totalInstallmentWithZeroPercent > 0 && (
-              <div>
-                <Label className="font-semibold">Total Installment With 0% Interest:</Label>
-                <Label className="ml-2">₱{paymentDifferences.totalInstallmentWithZeroPercent.toLocaleString()}</Label>
-              </div>
-            )}
-          </div>
-        </CardContent>
       )}
     </Card>
   );

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -80,8 +80,7 @@ const Navbar: React.FC = () => {
               <SheetHeader>
                 <SheetTitle>Navigation</SheetTitle>
                 <SheetDescription>
-                  This action cannot be undone. This will permanently delete your account and remove your data from our
-                  servers.
+                  Browse the calculator, documentation, and bank conversion resources.
                 </SheetDescription>
               </SheetHeader>
               <div className="grid gap-3 py-3">

--- a/constant/_bank-conversion-list-data.ts
+++ b/constant/_bank-conversion-list-data.ts
@@ -1,53 +1,214 @@
 export const BANK_CONVERSION_LIST_MD = `
-Below is a list of bank transaction conversion to installment products along with their details, including rates and processing fees where available.
+Below is a comprehensive list of Philippine bank installment products — Balance Conversion, Credit-to-Cash, and Personal Loans — along with their details, typical rates, and links.
 
-### Products
+---
 
-#### BPI
+## Balance Conversion Programs
 
-**Product:** [Balance Conversion](https://www.bpi.com.ph/personal/cards/credit-cards/sip-loans/balance-conversion#:~:text=your%20credit%20limit.-,Rates,-Term)
+Convert existing credit card purchases or outstanding balances into fixed monthly installments.
 
-#### Asia United Bank
+### BPI
 
-**Product:** [Post Pay Installment](https://www.aub.com.ph/creditcards/postpay#:~:text=What%20is%20Post%20Pay%20Installment,monthly%20add%2Don%20interest%20rate.)
+**Product:** [Balance Conversion](https://www.bpi.com.ph/personal/cards/credit-cards/sip-loans/balance-conversion)
 
-#### Bank of Commerce
+- Standard rate: 0.99%/month
+- Promo rates: As low as 0.49%–0.69%/month (invite-only)
+- Terms: 6, 12, 18, 24, 36, 48, 60 months
+- Processing fee: ₱300 (up to ₱50K) or ₱500 (above ₱50K)
 
-**Product:** [Convert to Installment](https://www.bankcom.com.ph/personal/credit-cards/convert-install-terms-conditions/#:~:text=Card%20T%26C.-,Program%20Mechanics,-1.%20The%20Convert)
+### BDO
 
-#### Eastwest Bank
+**Product:** [Balance Convert](https://www.bdo.com.ph/personal/cards/credit-cards/installment-programs)
 
-**Product:** [Convert-to-Installment ("CTI")](https://www.eastwestbanker.com/promos/flexible-payment-terms-eastwest-credit-cards-convert-installment-facility)
+- Standard rate: ~0.88%/month
+- Promo rates: As low as 0.59%/month
+- Terms: Up to 60 months
+- Processing fee: ₱350
 
-#### HSBC
-
-**Product:** [Card Balance Conversion](https://www.hsbc.com.ph/credit-cards/features/balance-conversion/#:~:text=for%20Platinum%20Visa-,Terms%20and%20conditions,-HSBC%27s%20Card%20Balance)
-
-#### Maybank
-
-**Product:** [EzyConvert Promo](https://www.maybank.com.ph/en/personal/cards/ezyplans/ezyconvert-promo.page?#:~:text=What%20are%20the%20other%20rates%20available%20and%20how%20do%20I%20compute%20for%20my%20monthly%20amortization%3F)
-
-#### Metrobank
+### Metrobank
 
 **Product:** [Balance Conversion](https://www.metrobankcard.com/cardsservices/balance-conversion)
 
-#### PNB
+- Standard rate: Up to 1.00%/month
+- Promo rates: 0.55%/month (Balance Transfer promo)
+- Terms: 3–60 months
+- Processing fee: ₱500
 
-**Product:** [Installment Programs - Transaction Conversion](https://www.pnb.com.ph/index.php/credit-cards?tpl=revamp#:~:text=Installment%20Programs)
+### Security Bank
 
-#### RCBC
+**Product:** [Balance Convert (BalCon)](https://www.securitybank.com/personal/credit-cards/installment-and-payments/balance-convert/)
 
-**Product:** [UNLI Installment](https://rcbccredit.com/features-and-benefits/budget-management/unli-zero#:~:text=Terms%20and%20Rates%20for%20UNLI%20Installment)
+- Rate: Personalized (invite-based)
+- Terms: 3, 6, 9, 12, 18, 24 months
+- Processing fee: Varies
 
-#### Security Bank
+### UnionBank
 
-**Product:** [ChargeLight](https://www.securitybank.com/personal/credit-cards/installment-and-payments/chargelight/#:~:text=Select%20your%20Preferred%20ChargeLight%20Term)
+**Product:** [EasyConvert](https://www.unionbankph.com/easyinstallments)
 
-#### Unionbank
+- Rate: Personalized
+- Terms: Varies
+- Processing fee: Varies
 
-**Product:** [Easy Installments - EasyConvert](https://www.unionbankph.com/easyinstallments)
+### HSBC
 
------
+**Product:** [Card Balance Conversion](https://www.hsbc.com.ph/credit-cards/features/balance-conversion/)
 
-**Note:** Please note that the links provided may not be accurate, and I'm not sure if they are the correct ones. It is advisable to double-check the details and rates directly with the respective banks before making any decisions or transactions.
+- Standard rate: Up to 1.00%/month
+- Terms: Up to 24 months
+- Processing fee: Varies
+
+### RCBC
+
+**Product:** [UNLI Installment](https://rcbccredit.com/features-and-benefits/budget-management/unli-zero)
+
+- Rate: Personalized (up to 1%/month)
+- Terms: Varies
+
+### Asia United Bank
+
+**Product:** [Post Pay Installment](https://www.aub.com.ph/creditcards/postpay)
+
+### Bank of Commerce
+
+**Product:** [Convert to Installment](https://www.bankcom.com.ph/personal/credit-cards/convert-install-terms-conditions/)
+
+### Eastwest Bank
+
+**Product:** [Convert-to-Installment (CTI)](https://www.eastwestbanker.com/promos/flexible-payment-terms-eastwest-credit-cards-convert-installment-facility)
+
+### Maybank
+
+**Product:** [EzyConvert Promo](https://www.maybank.com.ph/en/personal/cards/ezyplans/ezyconvert-promo.page)
+
+### PNB
+
+**Product:** [Transaction Conversion](https://www.pnb.com.ph/index.php/credit-cards)
+
+---
+
+## Credit-to-Cash Programs
+
+Convert available (unused) credit limit into cash deposited to your bank account.
+
+### BPI
+
+**Product:** [Credit-to-Cash](https://www.bpi.com.ph/personal/cards/credit-cards/sip-loans/credit-to-cash)
+
+- Standard rate: 0.99%/month
+- Promo rates: 0.49%–0.69%/month (invite-only)
+- Terms: 6–60 months
+- Processing fee: ₱300–₱500
+- Min amount: ₱3,000; up to 100% of available credit limit
+
+### Metrobank
+
+**Product:** [Cash2Go](https://www.metrobank.com.ph/cards/credit-cards/services/cash2go)
+
+- Standard rate: Up to 1%/month (promo: 0.68%)
+- Terms: 3–60 months
+- Processing fee: ₱350
+
+### BDO
+
+**Product:** [Cash It Easy / Avail Cash Now](https://www.bdo.com.ph/personal/cards/credit-cards/installment-programs)
+
+- Rate: Personalized (up to 1%/month)
+- Terms: Up to 36 months
+- Min amount: ₱10,000
+
+### Security Bank
+
+**Product:** [Ready Cash](https://www.securitybank.com/personal/credit-cards/installment-and-payments/)
+
+- Rate: Personalized
+- Terms: 3–24 months
+- Min amount: ₱10,000
+
+### RCBC
+
+**Product:** [YourCash](https://rcbccredit.com/features-and-benefits/budget-management/easy-terms/in-store)
+
+- Rate: Personalized (up to 1%/month)
+- Processing fee: ₱250 (RCBC deposit) or ₱350 (non-RCBC)
+- Min: ₱20,000; Max: ₱500,000
+
+---
+
+## Personal Loan Products
+
+Standalone unsecured bank loans — separate from credit cards.
+
+### BDO
+
+**Product:** [Personal Loan](https://www.bdo.com.ph/personal/loans/personal-loan)
+
+- Monthly add-on rate: ~1.39%–1.79%
+- Approx. EIR: 18%–24% p.a.
+- Terms: 6–36 months
+- Processing fee: ₱1,300
+- DST: 0.75% of loan (for loans above ₱250K)
+- Loan range: Up to ₱3M
+
+### BPI
+
+**Product:** [Personal Loan](https://www.bpi.com.ph/personal/loans/personal-loan/regular)
+
+- Monthly add-on rate: ~1.20%
+- Approx. EIR: 25%–29% p.a.
+- Terms: 12–36 months
+- Processing fee: ₱1,500
+- DST: 0.75% of loan (for loans above ₱250K)
+- Loan range: ₱20K–₱3M
+
+### Metrobank
+
+**Product:** [Personal Loan](https://www.metrobank.com.ph/articles/personal-loan-rates-and-fees)
+
+- Monthly add-on rate: ~1.25%
+- Approx. EIR: 30%–33% p.a.
+- Terms: 12–36 months
+- Processing fee: ₱1,500 (disbursement fee)
+- Loan range: Up to ₱2M
+
+### UnionBank
+
+**Product:** [Personal Loan](https://www.unionbankph.com/personal-loan)
+
+- Rate: Personalized
+- Terms: Varies
+- Loan range: Up to ₱2M
+
+---
+
+## 0% Installment Programs (Merchant Installment / SIP)
+
+Buy from partner merchants at 0% interest — the merchant subsidizes the cost.
+
+| Bank | Program | Terms | Min Purchase |
+|------|---------|-------|-------------|
+| BPI | Real 0% SIP / FlexipayZero | Up to 36 months | ₱3,000 |
+| BDO | 0% Installment | Up to 24 months | Varies |
+| Metrobank | 0% Installment | 3–36 months | Varies |
+| HSBC | Card Instalment Plan (HIP) | Up to 36 months | Varies |
+| RCBC | Easyterms / Unli 0% | 3 months (Unli 0%); up to 36 months | No min (Unli 0%) |
+| Security Bank | ChargeLight | 3–24 months | ₱5,000 |
+| EastWest | 0% Installment | Up to 24 months | ₱3,000 |
+| PNB | ZAPP | Up to 24 months | Varies |
+
+---
+
+## BSP Regulatory Caps
+
+| Regulation | Limit |
+|------------|-------|
+| Credit card revolving interest | 3% per month / 36% per annum |
+| Installment loan add-on rate | 1% per month maximum |
+| Cash advance processing fee | ₱200 per transaction maximum |
+
+*Source: BSP Circular No. 1098 (2020), updated by Circular No. 1165 (2023).*
+
+---
+
+**Note:** Rates and fees shown are based on publicly available information and may change. Promo rates are often invitation-only. Always verify details directly with the respective banks before making any financial decisions.
 `;

--- a/constant/_guide-data.ts
+++ b/constant/_guide-data.ts
@@ -1,66 +1,147 @@
-export const GUIDE_MD = `## Installment Options - How I Calculate it and How They Work
+export const GUIDE_MD = `## Savvy Spender — How the Calculators Work
 
 ### Introduction
 
-I've found that understanding installment options can be incredibly useful when it comes to managing finances and making substantial purchases. In this explanation, I'll share how I calculate installment options and provide a step-by-step guide on how they work. Please note that while I've made every effort to ensure accuracy, I'm not entirely certain if this is the correct calculation. If you have any doubts or corrections, please feel free to share them.
+Understanding your installment and loan options is key to making smart financial decisions. Savvy Spender supports three types of calculations commonly used in the Philippines:
 
-### Key Input Parameters
+1. **Balance Conversion** — Compare bank installment vs. 0% merchant installment when you buy something with a credit card.
+2. **Credit-to-Cash** — Calculate how much you'll pay when converting available credit into cash.
+3. **Personal Loan** — Estimate payments for a bank personal loan including Documentary Stamp Tax (DST).
 
-Before diving into the calculations, it's essential to gather the following key input parameters:
+All calculations use the **add-on (flat) rate method**, which is the standard used by Philippine banks for credit card installments and most unsecured personal loans.
 
-- **Principal Amount**: This is the total amount you want to finance or purchase.
-- **Interest Rate**: The monthly interest rate as a decimal (e.g., 1% as 0.01).
-- **Processing Fee (optional)**: Any additional fees associated with the installment plan.
-- **Number of Installments**: The number of months over which you want to spread your payments.
+---
 
-### Step-by-Step Calculation
+### How Add-On (Flat) Interest Works
 
-Let's walk through the process of calculating installment options with a detailed example using your specific calculation method:
+Philippine banks charge interest on the **original principal** for the entire term — not on the declining balance. This is called the "add-on" or "flat" method.
 
-**Example Input**:
+- **Monthly Interest** = Principal × Monthly Rate
+- **Total Interest** = Principal × Monthly Rate × Number of Months
+- **Monthly Payment** = (Principal + Total Interest) / Number of Months
 
-- Principal Amount: ₱30,000
-- Interest Rate: 1% (monthly interest rate)
-- Processing Fee: ₱0
-- Number of Installments: 12 months
+This is simpler to compute, but the **Effective Interest Rate (EIR)** is roughly 1.8×–2.0× higher than the stated add-on rate.
 
-**Step 1: Calculate Simple Interest**
+> **BSP Regulation:** The Bangko Sentral ng Pilipinas caps the monthly add-on rate for credit card installment loans at **1.00% per month** (BSP Circular No. 1098, retained by Circular No. 1165).
 
-- Start by calculating the simple interest for the loan period:
-  - Simple Interest = **Principal Amount - Monthly Interest Rate - Number of Installments**
-  - Simple Interest = **₱30,000 - 0.01 - 12 = ₱3,600**
+---
 
-**Step 2: Calculate Factor Rate**
+### Calculator 1: Balance Conversion
 
-- Compute the factor rate:
-  - Factor Rate = **(1 + (Simple Interest / Principal Amount)) / Number of Installments**
-  - Factor Rate = **(1 + (₱3,600 / ₱30,000)) / 12 = 0.0933**
+This is for when you **buy something with your credit card** and want to compare your options:
 
-**Step 3: Calculate Monthly Payment**
+- **Full cash payment** — Pay the cash price outright.
+- **0% merchant installment** — The merchant may offer a 0% interest plan (often at a slightly higher total price).
+- **Bank balance conversion** — The bank converts your balance to installments with monthly add-on interest.
 
-- Determine the monthly payment:
-  - Monthly Payment = **(Principal Amount + Simple Interest) / Number of Installments**
-  - Monthly Payment = **(₱30,000 + ₱3,600) / 12 = ₱2,800**
+#### Key Input Parameters
 
-**Step 4: Calculate Effective Interest Rate PA (EIR PA)**
+- **Principal / Amount** — The full cash price of the item.
+- **Interest Rate** — Monthly add-on rate (e.g., 0.99%).
+- **Installment Amount** (optional) — The total amount under a 0% merchant installment plan.
+- **Processing Fee** (optional) — Typically ₱300–₱500 per availment.
+- **Monthly Budget** (optional) — Highlights which plans fit your budget.
 
-- Calculate the Effective Interest Rate per annum (EIR PA):
-  - EIR PA = **RATE(Number of Installments, -Factor Rate, 1) \* 12**
-  - EIR PA = **21.46%** _(I'm using the RATE function of the excel)_
+#### Step-by-Step Example
 
-**Step 5: Calculate Total Payment**
+**Input:** ₱30,000 item, 1% monthly rate, 12 months, no processing fee.
 
-- Calculate the total payment over the loan period:
-  - Total Payment = **(Principal Amount + Simple Interest) + Processing Fee**
-  - Total Payment = **(₱30,000 + ₱3,600) + ₱0 = ₱33,600**
+**Step 1 — Simple Interest:**
+Simple Interest = ₱30,000 × 0.01 × 12 = **₱3,600**
 
-**Step 6: Review and Decision**
+**Step 2 — Factor Rate:**
+Factor Rate = (1 + 3,600 / 30,000) / 12 = **0.0933**
 
-- Review the installment plan details:
-  - Months: **12**
-  - Simple Interest: **₱3,600**
-  - Factor Rate: **0.0933**
-  - EIR PA: **21.46%**
-  - Monthly Payment: **₱2,800**
-  - Total Payment: **₱33,600**
+**Step 3 — Monthly Payment:**
+Monthly Payment = (₱30,000 + ₱3,600) / 12 = **₱2,800**
+
+**Step 4 — Effective Interest Rate PA (EIR PA):**
+Using the Excel RATE function: EIR PA = **~21.46%**
+
+**Step 5 — Total Payment:**
+Total Payment = ₱30,000 + ₱3,600 + ₱0 (processing fee) = **₱33,600**
+
+#### Optimal Principal Insight
+
+If you provide a 0% installment amount, the calculator uses binary search to find the ideal principal where the bank's total installment (with interest) stays just under the 0% plan total. This helps you decide: *should I take the bank conversion or the 0% merchant plan?*
+
+---
+
+### Calculator 2: Credit-to-Cash
+
+Credit-to-Cash (also called Cash2Go, CashLite, Ready Cash, YourCash depending on the bank) converts your **available credit limit** into actual cash deposited to your bank account.
+
+#### How It Differs from Balance Conversion
+
+| Feature | Balance Conversion | Credit-to-Cash |
+|---------|-------------------|----------------|
+| Source | Existing purchases already on card | Unused available credit limit |
+| Output | Balance restructured into installments | Cash deposited to your account |
+| Use case | Managing a large purchase | Emergency cash, paying bills |
+
+#### Calculation
+
+The math is **identical** to Balance Conversion (add-on/flat rate). The only difference is context — you're converting unused credit to cash rather than restructuring a purchase.
+
+#### Typical Fees
+
+- Processing fee: ₱250–₱500 per availment
+- Terms: 3–36 months (up to 60 at some banks)
+- Rates: 0.49%–1.00% monthly add-on (varies by bank and promo)
+
+---
+
+### Calculator 3: Personal Loan
+
+Personal loans are standalone, unsecured bank loans — separate from credit cards.
+
+#### Key Difference: Documentary Stamp Tax (DST)
+
+Personal loans above ₱250,000 are subject to **Documentary Stamp Tax** under the Philippine NIRC:
+
+- **Rate:** ₱1.50 per ₱200 of loan face value (~0.75%)
+- **Exemption:** Loans of ₱250,000 and below for personal use are exempt
+- **DST is deducted from loan proceeds** at disbursement
+
+#### Example
+
+**Input:** ₱500,000 loan, 1.25% monthly rate, 36 months, ₱1,500 origination fee.
+
+- DST = (500,000 / 200) × 1.50 = **₱3,750**
+- Net Proceeds = ₱500,000 − ₱3,750 − ₱1,500 = **₱494,750** (what you actually receive)
+- Total Interest = ₱500,000 × 0.0125 × 36 = **₱225,000**
+- Monthly Payment = (₱500,000 + ₱225,000) / 36 = **₱20,138.89**
+- Total Payable = ₱725,000 + ₱5,250 (fees) = **₱730,250**
+
+> You borrow ₱500K but only receive ₱494,750 — yet you pay interest on the full ₱500K.
+
+#### Typical Personal Loan Rates (PH Banks)
+
+| Bank | Monthly Add-On Rate | Approx. EIR (Annual) | Terms |
+|------|--------------------|--------------------|-------|
+| BDO | 1.39%–1.79% | 18%–24% | 6–36 months |
+| BPI | ~1.20% | 25%–29% | 12–36 months |
+| Metrobank | ~1.25% | 30%–33% | 12–36 months |
+
+---
+
+### Understanding the Results
+
+#### Simple Interest (%)
+Total interest as a percentage of the principal. Formula: (Principal × Rate × Months) / Principal × 100.
+
+#### Factor Rate
+The multiplier that converts 1 unit of principal into the per-period payment. Formula: (1 + Simple Interest %) / Months.
+
+#### Effective Interest Rate PA (EIR PA)
+The true annualized cost of borrowing, accounting for the declining balance effect. Calculated using the Excel RATE function internally. This is always significantly higher than the stated add-on rate.
+
+#### Monthly Budget Highlighting
+If you provide a monthly budget, plans where the monthly payment fits within your budget appear in **green**. Plans that exceed your budget appear in **red**.
+
+---
+
+### Disclaimer
+
+Different banks may offer varying conversion terms, rates, and promos. The information provided here is for **reference purposes only**. Rates shown are add-on (flat) rates — the effective interest rate (EIR) will always be higher. Always verify details directly with the respective banks before making financial decisions.
 `;

--- a/constant/index.ts
+++ b/constant/index.ts
@@ -1,1 +1,91 @@
 export const INSTALLMENT_PLAN_LIST = ["3", "6", "9", "12", "15", "18", "21", "24", "27", "30", "33", "36"];
+
+export const PERSONAL_LOAN_PLAN_LIST = ["6", "12", "18", "24", "30", "36"];
+
+export const CALCULATOR_TYPES = [
+  {
+    value: "balance-conversion",
+    label: "Balance Conversion",
+    description: "Bought something with your credit card? Compare bank installment vs. 0% merchant plans.",
+  },
+  {
+    value: "credit-to-cash",
+    label: "Credit-to-Cash",
+    description: "Convert your available credit limit into cash deposited to your bank account.",
+  },
+  {
+    value: "personal-loan",
+    label: "Personal Loan",
+    description: "Calculate bank personal loan payments with DST and origination fees.",
+  },
+] as const;
+
+export type CalculatorType = (typeof CALCULATOR_TYPES)[number]["value"];
+
+export const CALCULATOR_CONFIG: Record<
+  CalculatorType,
+  {
+    amountLabel: string;
+    amountPlaceholder: string;
+    amountDescription: string;
+    showInstallmentAmount: boolean;
+    showDST: boolean;
+    installmentPlans: string[];
+    processingFeeLabel: string;
+    processingFeePlaceholder: string;
+    processingFeeDescription: string;
+    defaultInterestRate: number;
+    defaultProcessingFee: number;
+  }
+> = {
+  "balance-conversion": {
+    amountLabel: "Principal / Amount",
+    amountPlaceholder: "Enter principal or amount of the item",
+    amountDescription:
+      "The full cash price of the item or total amount that will be converted into bank installments.",
+    showInstallmentAmount: true,
+    showDST: false,
+    installmentPlans: INSTALLMENT_PLAN_LIST,
+    processingFeeLabel: "Processing Fee",
+    processingFeePlaceholder: "Enter processing fee (e.g., 300-500)",
+    processingFeeDescription:
+      "One-time fee charged by the bank for the conversion (typically ₱300–₱500).",
+    defaultInterestRate: 0.99,
+    defaultProcessingFee: 0,
+  },
+  "credit-to-cash": {
+    amountLabel: "Amount to Convert",
+    amountPlaceholder: "Enter amount to convert to cash",
+    amountDescription:
+      "The amount from your available credit limit you want to receive as cash in your bank account.",
+    showInstallmentAmount: false,
+    showDST: false,
+    installmentPlans: INSTALLMENT_PLAN_LIST,
+    processingFeeLabel: "Processing Fee",
+    processingFeePlaceholder: "Enter processing fee (e.g., 250-500)",
+    processingFeeDescription:
+      "One-time fee charged by the bank for the cash conversion (typically ₱250–₱500).",
+    defaultInterestRate: 0.99,
+    defaultProcessingFee: 0,
+  },
+  "personal-loan": {
+    amountLabel: "Loan Amount",
+    amountPlaceholder: "Enter loan amount",
+    amountDescription:
+      "The total amount you want to borrow. Net proceeds will be less after DST and fees are deducted.",
+    showInstallmentAmount: false,
+    showDST: true,
+    installmentPlans: PERSONAL_LOAN_PLAN_LIST,
+    processingFeeLabel: "Origination / Disbursement Fee",
+    processingFeePlaceholder: "Enter origination fee (e.g., 1300-1500)",
+    processingFeeDescription:
+      "Bank disbursement or origination fee deducted from loan proceeds (typically ₱1,300–₱1,500).",
+    defaultInterestRate: 1.25,
+    defaultProcessingFee: 1500,
+  },
+};
+
+/** DST rate: ₱1.50 per ₱200 of loan face value (~0.75%) */
+export const DST_RATE_PER_200 = 1.5;
+/** Loans at or below this amount are DST-exempt for personal use */
+export const DST_EXEMPTION_THRESHOLD = 250000;

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -19,6 +19,9 @@ export type AllInstallmentOption = {
   selected?: InstallmentOption;
   others: Array<InstallmentOption>;
   monthlyBudget?: number;
+  calculatorType?: string;
+  dst?: number;
+  netProceeds?: number;
 };
 
 export type PaymentDifferences = {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -4,3 +4,15 @@ export const cleanMarkdown = (content: string): string => {
     .map((line) => line.trimStart())
     .join("\n");
 };
+
+export const formatCurrency = (amount: number | string): string => {
+  const num = typeof amount === "string" ? parseFloat(amount) : amount;
+  if (isNaN(num)) return "₱0.00";
+  return `₱${num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+};
+
+export const formatPercent = (value: number | string): string => {
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (isNaN(num)) return "0%";
+  return `${num}%`;
+};

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "savvy-spender",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/schema/index.ts
+++ b/schema/index.ts
@@ -2,19 +2,27 @@ import { z } from "zod";
 
 export const CalculateFormSchema = z
   .object({
-    amount: z.coerce.number().min(1).nonnegative(),
+    calculatorType: z.enum(["balance-conversion", "credit-to-cash", "personal-loan"]).default("balance-conversion"),
+    amount: z.coerce.number().min(1, "Amount must be at least 1"),
     interestRate: z.coerce
       .number()
       .transform((value) => value / 100) // Convert percentage to decimal
       .refine((val) => !isNaN(val) && val >= 0 && val <= 1, "Interest rate must be a percentage between 0% and 100%"),
     numInstallments: z.enum(["3", "6", "9", "12", "15", "18", "21", "24", "27", "30", "33", "36"]).default("3"),
     processingFee: z.coerce.number().min(0).optional(),
-    installmentAmount: z.coerce.number().min(0).nonnegative(),
+    installmentAmount: z.coerce.number().min(0),
     monthlyBudget: z.coerce.number().min(0).optional(),
   })
-  .refine((data) => data.installmentAmount === 0 || data.installmentAmount > data.amount, {
-    message: "Installment amount must be 0 or greater than the principal/amount",
-    path: ["installmentAmount"],
-  });
+  .refine(
+    (data) => {
+      // installmentAmount validation only applies for balance-conversion
+      if (data.calculatorType !== "balance-conversion") return true;
+      return data.installmentAmount === 0 || data.installmentAmount > data.amount;
+    },
+    {
+      message: "Installment amount must be 0 or greater than the principal/amount",
+      path: ["installmentAmount"],
+    }
+  );
 
 export type CalculateForm = z.infer<typeof CalculateFormSchema>;


### PR DESCRIPTION
- Add calculator type selector: Balance Conversion (original), Credit-to-Cash, Personal Loan
- Balance Conversion retains original core feature: compare bank installment vs. 0% merchant plans
- Credit-to-Cash: convert available credit limit to cash with same add-on rate calculation
- Personal Loan: adds DST calculation (₱1.50/₱200, exempt ≤ ₱250K), net proceeds preview
- Fix bugs: wrong placeholder text in Monthly Budget, wrong SheetDescription in navbar,
  unused import in API route, budget highlighting only when budget is set, ₱0 display fix
- Rename isLoading to hasCalculated for clarity
- Update color scheme from grayscale to professional blue theme (finance-appropriate)
- Update documentation with all 3 calculator types, add-on rate explanation, BSP caps
- Expand bank conversion list with Credit-to-Cash programs, Personal Loan products,
  0% SIP programs, and BSP regulatory caps
- Context-aware form labels and descriptions per calculator type
- Conditional suggested principal and 0% comparison (only for Balance Conversion)

https://claude.ai/code/session_01BaZw91wJautwqikhq18nyP