### PR TITLE
Add expanded month input modes and financial tools page

### DIFF
--- a/app/api/tools/route.ts
+++ b/app/api/tools/route.ts
@@ -1,0 +1,258 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  calculateAffordability,
+  compareLoanOffers,
+  calculateEarlyPayoff,
+  convertInterestRate,
+  calculateBreakEven,
+  calculateInHouseLoan,
+  calculateSalary,
+  calculateIncomeTax,
+  calculateFreelancerTax,
+  calculateDebtPayoff,
+  calculateSavingsGoal,
+  calculateSSSLoan,
+  calculatePagIBIGLoan,
+  calculateCreditCardPayoff,
+  calculateCarLoan,
+  calculateRemittance,
+  calculateInvestmentReturn,
+  calculateRetirement,
+  calculateEmergencyFund,
+} from "@/lib/calculators";
+
+type ToolName =
+  | "affordability"
+  | "loan-comparison"
+  | "early-payoff"
+  | "rate-converter"
+  | "break-even"
+  | "in-house-loan"
+  | "salary"
+  | "tax"
+  | "debt-planner"
+  | "savings-goal"
+  | "sss-loan"
+  | "pagibig-loan"
+  | "credit-card-payoff"
+  | "car-loan"
+  | "remittance"
+  | "investment"
+  | "retirement"
+  | "emergency-fund";
+
+interface ToolRequest {
+  tool: ToolName;
+  params: Record<string, unknown>;
+}
+
+function handleTool(tool: ToolName, params: Record<string, unknown>): unknown {
+  switch (tool) {
+    case "affordability": {
+      const { monthlyBudget, monthlyRate, months, processingFee = 0 } = params as {
+        monthlyBudget: number;
+        monthlyRate: number;
+        months: number[];
+        processingFee?: number;
+      };
+      return months.map((m) => calculateAffordability(monthlyBudget, monthlyRate, m, processingFee));
+    }
+
+    case "loan-comparison": {
+      const { principal, offerA, offerB, months } = params as {
+        principal: number;
+        offerA: { name: string; rate: number; processingFee: number };
+        offerB: { name: string; rate: number; processingFee: number };
+        months: number[];
+      };
+      return months.map((m) => compareLoanOffers(principal, offerA, offerB, m));
+    }
+
+    case "early-payoff": {
+      const { principal, monthlyRate, originalMonths, extraPayment, processingFee = 0 } = params as {
+        principal: number;
+        monthlyRate: number;
+        originalMonths: number;
+        extraPayment: number;
+        processingFee?: number;
+      };
+      return calculateEarlyPayoff(principal, monthlyRate, originalMonths, extraPayment, processingFee);
+    }
+
+    case "rate-converter": {
+      const { flatRateMonthly, months } = params as { flatRateMonthly: number; months: number };
+      return convertInterestRate(flatRateMonthly, months);
+    }
+
+    case "break-even": {
+      const { cashPrice, installmentPriceZero, monthlyRate, processingFee, maxMonths = 36 } = params as {
+        cashPrice: number;
+        installmentPriceZero: number;
+        monthlyRate: number;
+        processingFee: number;
+        maxMonths?: number;
+      };
+      return calculateBreakEven(cashPrice, installmentPriceZero, monthlyRate, processingFee, maxMonths);
+    }
+
+    case "in-house-loan": {
+      const { totalPrice, downPaymentPercent, monthlyRate, months, balloonPayment = 0 } = params as {
+        totalPrice: number;
+        downPaymentPercent: number;
+        monthlyRate: number;
+        months: number;
+        balloonPayment?: number;
+      };
+      return calculateInHouseLoan(totalPrice, downPaymentPercent, monthlyRate, months, balloonPayment);
+    }
+
+    case "salary": {
+      const { grossMonthly } = params as { grossMonthly: number };
+      return calculateSalary(grossMonthly);
+    }
+
+    case "tax": {
+      const { annualIncome, isFreelancer = false } = params as { annualIncome: number; isFreelancer?: boolean };
+      return isFreelancer ? calculateFreelancerTax(annualIncome) : calculateIncomeTax(annualIncome);
+    }
+
+    case "debt-planner": {
+      const { debts, extraPayment, method } = params as {
+        debts: Array<{ name: string; balance: number; monthlyRate: number; minimumPayment: number }>;
+        extraPayment: number;
+        method: "snowball" | "avalanche";
+      };
+      return calculateDebtPayoff(debts, extraPayment, method);
+    }
+
+    case "savings-goal": {
+      const { targetAmount, months, annualRate = 0 } = params as {
+        targetAmount: number;
+        months: number;
+        annualRate?: number;
+      };
+      return calculateSavingsGoal(targetAmount, months, annualRate);
+    }
+
+    case "sss-loan": {
+      const { loanAmount, annualRate = 0.1, termMonths = 24 } = params as {
+        loanAmount: number;
+        annualRate?: number;
+        termMonths?: number;
+      };
+      return calculateSSSLoan(loanAmount, annualRate, termMonths);
+    }
+
+    case "pagibig-loan": {
+      const { loanAmount, termYears = 30 } = params as { loanAmount: number; termYears?: number };
+      return calculatePagIBIGLoan(loanAmount, termYears);
+    }
+
+    case "credit-card-payoff": {
+      const {
+        balance,
+        annualRate,
+        minimumPaymentPercent = 0.03,
+        minimumPaymentFloor = 500,
+        fixedPayment = 0,
+      } = params as {
+        balance: number;
+        annualRate: number;
+        minimumPaymentPercent?: number;
+        minimumPaymentFloor?: number;
+        fixedPayment?: number;
+      };
+      return calculateCreditCardPayoff(balance, annualRate, minimumPaymentPercent, minimumPaymentFloor, fixedPayment);
+    }
+
+    case "car-loan": {
+      const { vehiclePrice, downPaymentPercent, monthlyRate, months } = params as {
+        vehiclePrice: number;
+        downPaymentPercent: number;
+        monthlyRate: number;
+        months: number;
+      };
+      return calculateCarLoan(vehiclePrice, downPaymentPercent, monthlyRate, months);
+    }
+
+    case "remittance": {
+      const { sendAmount, exchangeRate, fee, sendCurrency = "USD", receiveCurrency = "PHP" } = params as {
+        sendAmount: number;
+        exchangeRate: number;
+        fee: number;
+        sendCurrency?: string;
+        receiveCurrency?: string;
+      };
+      return calculateRemittance(sendAmount, exchangeRate, fee, sendCurrency, receiveCurrency);
+    }
+
+    case "investment": {
+      const { initialAmount, monthlyContribution, years, annualReturn, taxRate = 0.2 } = params as {
+        initialAmount: number;
+        monthlyContribution: number;
+        years: number;
+        annualReturn: number;
+        taxRate?: number;
+      };
+      return calculateInvestmentReturn(initialAmount, monthlyContribution, years, annualReturn, taxRate);
+    }
+
+    case "retirement": {
+      const {
+        currentAge,
+        retirementAge,
+        currentSavings,
+        monthlySavings,
+        expectedReturn,
+        monthlyExpenseInRetirement,
+        retirementDuration = 25,
+      } = params as {
+        currentAge: number;
+        retirementAge: number;
+        currentSavings: number;
+        monthlySavings: number;
+        expectedReturn: number;
+        monthlyExpenseInRetirement: number;
+        retirementDuration?: number;
+      };
+      return calculateRetirement(
+        currentAge,
+        retirementAge,
+        currentSavings,
+        monthlySavings,
+        expectedReturn,
+        monthlyExpenseInRetirement,
+        retirementDuration
+      );
+    }
+
+    case "emergency-fund": {
+      const { monthlyExpenses, targetMonths = 6, currentSavings = 0, monthlySavingsCapacity = 0 } = params as {
+        monthlyExpenses: number;
+        targetMonths?: number;
+        currentSavings?: number;
+        monthlySavingsCapacity?: number;
+      };
+      return calculateEmergencyFund(monthlyExpenses, targetMonths, currentSavings, monthlySavingsCapacity);
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${tool}`);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { tool, params } = (await request.json()) as ToolRequest;
+
+    if (!tool || !params) {
+      return NextResponse.json({ error: "Missing 'tool' or 'params' field" }, { status: 400 });
+    }
+
+    const result = handleTool(tool, params);
+    return NextResponse.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Internal server error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,9 +28,13 @@ export default function Home() {
       const calculatorType = (values.calculatorType ?? "balance-conversion") as CalculatorType;
       const config = CALCULATOR_CONFIG[calculatorType];
 
+      const installmentPlanList = values.customPlanList && values.customPlanList.length > 0
+        ? values.customPlanList
+        : config.installmentPlans;
+
       const response = await fetch("/api", {
         method: "POST",
-        body: JSON.stringify({ ...values, installmentPlanList: config.installmentPlans }),
+        body: JSON.stringify({ ...values, installmentPlanList }),
       });
 
       if (!response.ok) {

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+// Tool components - Loan Calculators
+import AffordabilityCalculator from "@/components/tools/affordability-calculator";
+import LoanComparison from "@/components/tools/loan-comparison";
+import EarlyPayoffCalculator from "@/components/tools/early-payoff-calculator";
+import InHouseLoanCalculator from "@/components/tools/in-house-loan-calculator";
+import SSSLoanCalculator from "@/components/tools/sss-loan-calculator";
+import PagIBIGLoanCalculator from "@/components/tools/pagibig-loan-calculator";
+import CarLoanCalculator from "@/components/tools/car-loan-calculator";
+
+// Tool components - Credit & Rates
+import InterestRateConverter from "@/components/tools/interest-rate-converter";
+import BreakEvenAnalyzer from "@/components/tools/break-even-analyzer";
+import CreditCardPayoff from "@/components/tools/credit-card-payoff";
+
+// Tool components - Income & Tax
+import SalaryCalculator from "@/components/tools/salary-calculator";
+import TaxCalculator from "@/components/tools/tax-calculator";
+
+// Tool components - Planning & Savings
+import DebtPlanner from "@/components/tools/debt-planner";
+import SavingsGoalCalculator from "@/components/tools/savings-goal-calculator";
+import RetirementCalculator from "@/components/tools/retirement-calculator";
+import EmergencyFundCalculator from "@/components/tools/emergency-fund-calculator";
+import RemittanceCalculator from "@/components/tools/remittance-calculator";
+import InvestmentCalculator from "@/components/tools/investment-calculator";
+
+type ToolCategory = "all" | "loans" | "credit" | "income" | "planning";
+
+interface ToolDef {
+  id: string;
+  title: string;
+  description: string;
+  category: ToolCategory;
+  component: React.FC;
+}
+
+const TOOLS: ToolDef[] = [
+  // Loan Calculators
+  {
+    id: "affordability",
+    title: "Affordability Calculator",
+    description: "Find the max amount you can borrow based on your monthly budget",
+    category: "loans",
+    component: AffordabilityCalculator,
+  },
+  {
+    id: "loan-comparison",
+    title: "Loan Comparison",
+    description: "Compare two bank offers side-by-side across all terms",
+    category: "loans",
+    component: LoanComparison,
+  },
+  {
+    id: "early-payoff",
+    title: "Early Payoff Calculator",
+    description: "See how extra payments accelerate your loan payoff",
+    category: "loans",
+    component: EarlyPayoffCalculator,
+  },
+  {
+    id: "in-house-loan",
+    title: "In-House Loan",
+    description: "Calculate developer/dealer direct financing with down payment",
+    category: "loans",
+    component: InHouseLoanCalculator,
+  },
+  {
+    id: "sss-loan",
+    title: "SSS Loan Calculator",
+    description: "Compute SSS salary loan amortization and total cost",
+    category: "loans",
+    component: SSSLoanCalculator,
+  },
+  {
+    id: "pagibig-loan",
+    title: "Pag-IBIG Housing Loan",
+    description: "Estimate Pag-IBIG housing loan payments with MRI and insurance",
+    category: "loans",
+    component: PagIBIGLoanCalculator,
+  },
+  {
+    id: "car-loan",
+    title: "Car Loan Calculator",
+    description: "Auto financing with down payment and chattel mortgage fees",
+    category: "loans",
+    component: CarLoanCalculator,
+  },
+  // Credit & Rates
+  {
+    id: "rate-converter",
+    title: "Interest Rate Converter",
+    description: "Convert flat/add-on rates to effective interest rate (EIR)",
+    category: "credit",
+    component: InterestRateConverter,
+  },
+  {
+    id: "break-even",
+    title: "Break-Even Analyzer",
+    description: "Find when bank installment becomes cheaper than merchant 0%",
+    category: "credit",
+    component: BreakEvenAnalyzer,
+  },
+  {
+    id: "credit-card-payoff",
+    title: "Credit Card Payoff",
+    description: "Compare minimum payments vs fixed payments to pay off faster",
+    category: "credit",
+    component: CreditCardPayoff,
+  },
+  // Income & Tax
+  {
+    id: "salary",
+    title: "Salary Calculator (PH)",
+    description: "Compute net take-home pay with SSS, PhilHealth, Pag-IBIG, and tax",
+    category: "income",
+    component: SalaryCalculator,
+  },
+  {
+    id: "tax",
+    title: "Tax Calculator (PH)",
+    description: "Income tax based on TRAIN law with freelancer 8% flat rate option",
+    category: "income",
+    component: TaxCalculator,
+  },
+  // Planning & Savings
+  {
+    id: "debt-planner",
+    title: "Debt Snowball / Avalanche",
+    description: "Optimize multi-debt payoff with snowball or avalanche strategy",
+    category: "planning",
+    component: DebtPlanner,
+  },
+  {
+    id: "savings-goal",
+    title: "Savings Goal Calculator",
+    description: "How much to save monthly to reach your financial target",
+    category: "planning",
+    component: SavingsGoalCalculator,
+  },
+  {
+    id: "retirement",
+    title: "Retirement Calculator",
+    description: "Project your retirement fund and check if you're on track",
+    category: "planning",
+    component: RetirementCalculator,
+  },
+  {
+    id: "emergency-fund",
+    title: "Emergency Fund",
+    description: "Calculate your target emergency fund and track progress",
+    category: "planning",
+    component: EmergencyFundCalculator,
+  },
+  {
+    id: "remittance",
+    title: "Remittance Calculator",
+    description: "Convert currencies with fees for OFW remittances",
+    category: "planning",
+    component: RemittanceCalculator,
+  },
+  {
+    id: "investment",
+    title: "Investment Returns",
+    description: "Project investment growth with contributions and tax",
+    category: "planning",
+    component: InvestmentCalculator,
+  },
+];
+
+const CATEGORIES: Array<{ value: ToolCategory; label: string; count: number }> = [
+  { value: "all", label: "All Tools", count: TOOLS.length },
+  { value: "loans", label: "Loans", count: TOOLS.filter((t) => t.category === "loans").length },
+  { value: "credit", label: "Credit & Rates", count: TOOLS.filter((t) => t.category === "credit").length },
+  { value: "income", label: "Income & Tax", count: TOOLS.filter((t) => t.category === "income").length },
+  { value: "planning", label: "Planning & Savings", count: TOOLS.filter((t) => t.category === "planning").length },
+];
+
+export default function ToolsPage() {
+  const [activeCategory, setActiveCategory] = useState<ToolCategory>("all");
+  const [activeTool, setActiveTool] = useState<string | null>(null);
+
+  const filteredTools = activeCategory === "all" ? TOOLS : TOOLS.filter((t) => t.category === activeCategory);
+  const ActiveComponent = activeTool ? TOOLS.find((t) => t.id === activeTool)?.component : null;
+
+  return (
+    <main className="p-4 space-y-6 max-w-7xl mx-auto">
+      {/* Page Header */}
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Financial Tools</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          A collection of Philippine-focused financial calculators to help you make smarter money decisions.
+        </p>
+      </div>
+
+      {/* Category Filter */}
+      <div className="flex flex-wrap gap-2">
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat.value}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-all border",
+              activeCategory === cat.value
+                ? "bg-primary text-primary-foreground border-primary shadow-sm"
+                : "bg-background text-muted-foreground border-border hover:bg-muted hover:text-foreground"
+            )}
+            onClick={() => {
+              setActiveCategory(cat.value);
+              setActiveTool(null);
+            }}
+          >
+            {cat.label}
+            <Badge variant="secondary" className={cn(
+              "text-[10px] px-1.5 py-0",
+              activeCategory === cat.value && "bg-primary-foreground/20 text-primary-foreground"
+            )}>
+              {cat.count}
+            </Badge>
+          </button>
+        ))}
+      </div>
+
+      {/* Active Tool */}
+      {activeTool && ActiveComponent && (
+        <div className="space-y-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-xs text-muted-foreground"
+            onClick={() => setActiveTool(null)}
+          >
+            &larr; Back to all tools
+          </Button>
+          <ActiveComponent />
+        </div>
+      )}
+
+      {/* Tool Grid */}
+      {!activeTool && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {filteredTools.map((tool) => (
+            <Card
+              key={tool.id}
+              className="cursor-pointer transition-all hover:shadow-md hover:border-primary/40 group"
+              onClick={() => setActiveTool(tool.id)}
+            >
+              <CardHeader className="pb-3">
+                <div className="flex items-start justify-between">
+                  <CardTitle className="text-sm font-semibold group-hover:text-primary transition-colors">
+                    {tool.title}
+                  </CardTitle>
+                  <Badge variant="outline" className="text-[10px] capitalize shrink-0 ml-2">
+                    {tool.category === "credit" ? "Credit" : tool.category === "income" ? "Income" : tool.category === "planning" ? "Planning" : "Loan"}
+                  </Badge>
+                </div>
+                <CardDescription className="text-xs">{tool.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/components/installment/card-form.tsx
+++ b/components/installment/card-form.tsx
@@ -1,19 +1,23 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Badge } from "@/components/ui/badge";
 import { CalculateForm, CalculateFormSchema } from "@/schema";
 import { CALCULATOR_TYPES, CALCULATOR_CONFIG, DST_EXEMPTION_THRESHOLD, DST_RATE_PER_200 } from "@/constant";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/client";
 import { InfoCircledIcon, ReloadIcon, UpdateIcon } from "@radix-ui/react-icons";
 import type { CalculatorType } from "@/constant";
+
+type MonthInputMode = "preset" | "custom" | "range" | "quick";
 
 interface CardInstallmentFormProps {
   onSubmit: (values: CalculateForm) => void;
@@ -31,6 +35,20 @@ const InfoTip: React.FC<{ content: string }> = ({ content }) => (
   </Tooltip>
 );
 
+const QUICK_PRESETS = [
+  { label: "Short Term", description: "3–6 months", months: ["3", "6"] },
+  { label: "Mid Term", description: "9–18 months", months: ["9", "12", "15", "18"] },
+  { label: "Long Term", description: "24–36 months", months: ["24", "27", "30", "33", "36"] },
+  { label: "All Terms", description: "3–36 months", months: ["3", "6", "9", "12", "15", "18", "21", "24", "27", "30", "33", "36"] },
+];
+
+const MONTH_MODE_TABS: Array<{ value: MonthInputMode; label: string; description: string }> = [
+  { value: "preset", label: "Preset", description: "Choose from standard terms" },
+  { value: "custom", label: "Custom", description: "Enter any month value" },
+  { value: "range", label: "Range", description: "Generate a custom range" },
+  { value: "quick", label: "Quick Fill", description: "Use preset groups" },
+];
+
 const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit, isLoading = false }) => {
   const form = useForm<CalculateForm>({
     resolver: zodResolver(CalculateFormSchema),
@@ -44,6 +62,14 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit, isL
       monthlyBudget: 0,
     },
   });
+
+  const [monthMode, setMonthMode] = useState<MonthInputMode>("preset");
+  const [customMonth, setCustomMonth] = useState<string>("");
+  const [rangeStart, setRangeStart] = useState(3);
+  const [rangeEnd, setRangeEnd] = useState(36);
+  const [rangeStep, setRangeStep] = useState(3);
+  const [selectedComparison, setSelectedComparison] = useState<string[]>([]);
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const calculatorType = form.watch("calculatorType") as CalculatorType;
   const amount = form.watch("amount");
@@ -61,15 +87,52 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit, isL
     return amount - estimatedDST - processingFee;
   }, [calculatorType, amount, estimatedDST, processingFee]);
 
+  // Generate range months
+  const rangeMonths = useMemo(() => {
+    const months: string[] = [];
+    for (let i = rangeStart; i <= rangeEnd; i += rangeStep) {
+      months.push(String(i));
+    }
+    return months;
+  }, [rangeStart, rangeEnd, rangeStep]);
+
+  // Compute the plan list based on mode + advanced comparison
+  const computePlanList = useCallback((): string[] => {
+    let basePlans: string[];
+    switch (monthMode) {
+      case "custom": {
+        const month = customMonth || form.getValues("numInstallments");
+        basePlans = Array.from(new Set([...config.installmentPlans, month])).sort((a, b) => +a - +b);
+        break;
+      }
+      case "range":
+        basePlans = rangeMonths;
+        break;
+      case "quick":
+      case "preset":
+      default:
+        basePlans = config.installmentPlans;
+        break;
+    }
+
+    // If advanced comparison months are selected, use those instead
+    if (showAdvanced && selectedComparison.length > 0) {
+      const selected = form.getValues("numInstallments");
+      return Array.from(new Set([...selectedComparison, selected])).sort((a, b) => +a - +b);
+    }
+
+    return basePlans;
+  }, [monthMode, customMonth, config.installmentPlans, rangeMonths, showAdvanced, selectedComparison, form]);
+
   useEffect(() => {
     const currentPlan = form.getValues("numInstallments");
-    if (!config.installmentPlans.includes(currentPlan)) {
-      form.setValue("numInstallments", config.installmentPlans[0] as CalculateForm["numInstallments"]);
+    if (monthMode === "preset" && !config.installmentPlans.includes(currentPlan)) {
+      form.setValue("numInstallments", config.installmentPlans[0]);
     }
     if (!config.showInstallmentAmount) {
       form.setValue("installmentAmount", 0);
     }
-  }, [calculatorType, config, form]);
+  }, [calculatorType, config, form, monthMode]);
 
   const handleReset = () => {
     form.reset({
@@ -81,6 +144,32 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit, isL
       installmentAmount: 0,
       monthlyBudget: 0,
     });
+    setMonthMode("preset");
+    setCustomMonth("");
+    setRangeStart(3);
+    setRangeEnd(36);
+    setRangeStep(3);
+    setSelectedComparison([]);
+    setShowAdvanced(false);
+  };
+
+  const handleFormSubmit = (values: CalculateForm) => {
+    const planList = computePlanList();
+    onSubmit({ ...values, customPlanList: planList });
+  };
+
+  const handleQuickPreset = (months: string[]) => {
+    setSelectedComparison(months);
+    setShowAdvanced(true);
+    if (months.length > 0) {
+      form.setValue("numInstallments", months[0]);
+    }
+  };
+
+  const toggleComparisonMonth = (month: string) => {
+    setSelectedComparison((prev) =>
+      prev.includes(month) ? prev.filter((m) => m !== month) : [...prev, month].sort((a, b) => +a - +b)
+    );
   };
 
   return (
@@ -122,7 +211,7 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit, isL
           </fieldset>
 
           <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-4">
               <fieldset disabled={isLoading} className="space-y-4">
                 {/* Amount Field */}
                 <FormField
@@ -175,37 +264,261 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit, isL
                   )}
                 />
 
-                {/* Number of Installments */}
-                <FormField
-                  name="numInstallments"
-                  control={form.control}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>
-                        Number of Installments (Months)
-                        <InfoTip content="Choose how many months to spread your payments. Longer terms mean lower monthly payments but higher total interest. The calculator will also show all other terms for comparison." />
-                      </FormLabel>
-                      <Select onValueChange={field.onChange} value={field.value}>
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select installment term" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {config.installmentPlans.map((num) => (
-                            <SelectItem key={num} value={num}>
-                              {num} months
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormDescription>
-                        The calculator will also show all other available terms for comparison.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
+                {/* Number of Installments - Enhanced */}
+                <div className="space-y-3">
+                  <Label className="text-sm font-medium">
+                    Number of Installments (Months)
+                    <InfoTip content="Choose how many months to spread your payments. Use Preset for standard terms, Custom to type any month, Range to generate a series, or Quick Fill for common groupings." />
+                  </Label>
+
+                  {/* Mode Tabs */}
+                  <div className="flex flex-wrap gap-1.5">
+                    {MONTH_MODE_TABS.map((tab) => (
+                      <button
+                        key={tab.value}
+                        type="button"
+                        disabled={isLoading}
+                        className={cn(
+                          "rounded-md px-3 py-1.5 text-xs font-medium transition-all border",
+                          monthMode === tab.value
+                            ? "bg-primary text-primary-foreground border-primary shadow-sm"
+                            : "bg-background text-muted-foreground border-border hover:bg-muted hover:text-foreground"
+                        )}
+                        onClick={() => setMonthMode(tab.value)}
+                      >
+                        {tab.label}
+                      </button>
+                    ))}
+                  </div>
+
+                  {/* Preset Mode */}
+                  {monthMode === "preset" && (
+                    <FormField
+                      name="numInstallments"
+                      control={form.control}
+                      render={({ field }) => (
+                        <FormItem>
+                          <Select onValueChange={field.onChange} value={field.value}>
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select installment term" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {config.installmentPlans.map((num) => (
+                                <SelectItem key={num} value={num}>
+                                  {num} months
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormDescription>
+                            Choose from standard bank installment terms.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
                   )}
-                />
+
+                  {/* Custom Mode */}
+                  {monthMode === "custom" && (
+                    <div className="space-y-2">
+                      <Input
+                        type="number"
+                        min={1}
+                        max={360}
+                        placeholder="Enter number of months (1–360)"
+                        value={customMonth}
+                        onChange={(e) => {
+                          setCustomMonth(e.target.value);
+                          if (e.target.value) {
+                            form.setValue("numInstallments", e.target.value);
+                          }
+                        }}
+                        disabled={isLoading}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Type any month value. The comparison table will include this along with standard terms.
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Range Mode */}
+                  {monthMode === "range" && (
+                    <div className="space-y-3">
+                      <div className="grid grid-cols-3 gap-2">
+                        <div>
+                          <Label className="text-xs text-muted-foreground">Start</Label>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={360}
+                            value={rangeStart}
+                            onChange={(e) => setRangeStart(Math.max(1, +e.target.value))}
+                            disabled={isLoading}
+                          />
+                        </div>
+                        <div>
+                          <Label className="text-xs text-muted-foreground">End</Label>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={360}
+                            value={rangeEnd}
+                            onChange={(e) => setRangeEnd(Math.max(1, +e.target.value))}
+                            disabled={isLoading}
+                          />
+                        </div>
+                        <div>
+                          <Label className="text-xs text-muted-foreground">Step</Label>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={60}
+                            value={rangeStep}
+                            onChange={(e) => setRangeStep(Math.max(1, +e.target.value))}
+                            disabled={isLoading}
+                          />
+                        </div>
+                      </div>
+                      {rangeMonths.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5">
+                          {rangeMonths.map((m) => (
+                            <Badge
+                              key={m}
+                              variant="secondary"
+                              className={cn(
+                                "cursor-pointer text-xs",
+                                form.getValues("numInstallments") === m && "bg-primary text-primary-foreground"
+                              )}
+                              onClick={() => form.setValue("numInstallments", m)}
+                            >
+                              {m}mo
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                      <p className="text-xs text-muted-foreground">
+                        Generated {rangeMonths.length} terms. Click a badge to select it as your primary term.
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Quick Fill Mode */}
+                  {monthMode === "quick" && (
+                    <div className="space-y-3">
+                      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                        {QUICK_PRESETS.map((preset) => (
+                          <button
+                            key={preset.label}
+                            type="button"
+                            disabled={isLoading}
+                            className={cn(
+                              "rounded-lg border-2 px-3 py-2 text-left transition-all",
+                              JSON.stringify(selectedComparison) === JSON.stringify(preset.months)
+                                ? "border-primary bg-primary/5 shadow-sm"
+                                : "border-border hover:border-primary/40 hover:bg-muted/50"
+                            )}
+                            onClick={() => handleQuickPreset(preset.months)}
+                          >
+                            <span className="block text-xs font-semibold">{preset.label}</span>
+                            <span className="block text-[10px] text-muted-foreground">{preset.description}</span>
+                          </button>
+                        ))}
+                      </div>
+                      {selectedComparison.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5">
+                          {selectedComparison.map((m) => (
+                            <Badge
+                              key={m}
+                              variant="secondary"
+                              className={cn(
+                                "cursor-pointer text-xs",
+                                form.getValues("numInstallments") === m && "bg-primary text-primary-foreground"
+                              )}
+                              onClick={() => form.setValue("numInstallments", m)}
+                            >
+                              {m}mo
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                      <p className="text-xs text-muted-foreground">
+                        Select a preset to populate comparison terms. Click a badge to set your primary term.
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Advanced: Customize Comparison Plans */}
+                  <div className="border rounded-lg">
+                    <button
+                      type="button"
+                      className="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+                      onClick={() => setShowAdvanced(!showAdvanced)}
+                    >
+                      <span>Customize Comparison Plans</span>
+                      <span className="text-[10px]">{showAdvanced ? "Hide" : "Show"}</span>
+                    </button>
+                    {showAdvanced && (
+                      <div className="px-3 pb-3 space-y-2 border-t pt-2">
+                        <p className="text-[10px] text-muted-foreground">
+                          Check which months to include in the comparison table:
+                        </p>
+                        <div className="grid grid-cols-4 sm:grid-cols-6 gap-2">
+                          {["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12",
+                            "15", "18", "21", "24", "27", "30", "33", "36", "42", "48", "60"].map((m) => (
+                            <label
+                              key={m}
+                              className="flex items-center gap-1.5 text-xs cursor-pointer"
+                            >
+                              <Checkbox
+                                checked={selectedComparison.includes(m)}
+                                onCheckedChange={() => toggleComparisonMonth(m)}
+                                disabled={isLoading}
+                              />
+                              {m}mo
+                            </label>
+                          ))}
+                        </div>
+                        <div className="flex gap-2 items-end">
+                          <div className="flex-1">
+                            <Label className="text-[10px] text-muted-foreground">Add custom month</Label>
+                            <Input
+                              type="number"
+                              min={1}
+                              max={360}
+                              placeholder="e.g., 45"
+                              className="h-7 text-xs"
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  e.preventDefault();
+                                  const val = (e.target as HTMLInputElement).value;
+                                  if (val && +val >= 1 && +val <= 360 && !selectedComparison.includes(val)) {
+                                    setSelectedComparison((prev) => [...prev, val].sort((a, b) => +a - +b));
+                                  }
+                                  (e.target as HTMLInputElement).value = "";
+                                }
+                              }}
+                              disabled={isLoading}
+                            />
+                          </div>
+                          {selectedComparison.length > 0 && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="text-xs h-7"
+                              onClick={() => setSelectedComparison([])}
+                            >
+                              Clear all
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
 
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                   {/* Processing Fee */}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -11,6 +11,7 @@ import {
   ReaderIcon,
   ListBulletIcon,
   InputIcon,
+  MixerHorizontalIcon,
 } from "@radix-ui/react-icons";
 import { useTheme } from "next-themes";
 import { useState } from "react";
@@ -36,6 +37,7 @@ const Navbar: React.FC = () => {
       {/* Middle navigation links hidden on mobile */}
       <div className="hidden md:flex-grow md:flex md:items-center md:justify-center space-x-4">
         <Link href="/">Calculator</Link>
+        <Link href="/tools">Financial Tools</Link>
         <Link href="/docs">Documentation</Link>
         <Link href="/bank-conversion-list">Bank Conversion List</Link>
         <Link
@@ -87,6 +89,10 @@ const Navbar: React.FC = () => {
                 <Button variant="ghost" className="justify-start" onClick={() => setOpen(!open)}>
                   <InputIcon className="mr-2 h-4 w-4" />
                   <Link href="/">Calculator</Link>
+                </Button>
+                <Button variant="ghost" className="justify-start" onClick={() => setOpen(!open)}>
+                  <MixerHorizontalIcon className="mr-2 h-4 w-4" />
+                  <Link href="/tools">Financial Tools</Link>
                 </Button>
                 <Button variant="ghost" className="justify-start" onClick={() => setOpen(!open)}>
                   <ReaderIcon className="mr-2 h-4 w-4" />

--- a/components/tools/affordability-calculator.tsx
+++ b/components/tools/affordability-calculator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer, useCallback } from "react";
 import {
   Card,
   CardHeader,
@@ -19,32 +19,68 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  calculateAffordability,
-  type AffordabilityResult,
-} from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { AffordabilityResult } from "@/lib/calculators";
 import { formatCurrency } from "@/lib/client";
 
 const TERM_OPTIONS = [3, 6, 9, 12, 18, 24, 36];
 
-export default function AffordabilityCalculator() {
-  const [monthlyBudget, setMonthlyBudget] = useState("");
-  const [monthlyRate, setMonthlyRate] = useState("");
-  const [processingFee, setProcessingFee] = useState("");
-  const [results, setResults] = useState<AffordabilityResult[] | null>(null);
+interface FormState {
+  monthlyBudget: string;
+  monthlyRate: string;
+  processingFee: string;
+}
 
-  const handleCalculate = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  monthlyBudget: "",
+  monthlyRate: "",
+  processingFee: "",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function AffordabilityCalculator() {
+  const [form, formDispatch] = useReducer(formReducer, initialState);
+  const setField = useCallback(
+    (field: keyof FormState, value: string) =>
+      formDispatch({ type: "SET_FIELD", field, value }),
+    []
+  );
+
+  const {
+    data: results,
+    isLoading,
+    error,
+    calculate,
+  } = useToolCalculator<AffordabilityResult[]>("affordability");
+
+  const handleCalculate = async (e: React.FormEvent) => {
     e.preventDefault();
-    const budget = parseFloat(monthlyBudget);
-    const rate = parseFloat(monthlyRate) / 100;
-    const fee = processingFee ? parseFloat(processingFee) : 0;
+    const budget = parseFloat(form.monthlyBudget);
+    const rate = parseFloat(form.monthlyRate) / 100;
+    const fee = form.processingFee ? parseFloat(form.processingFee) : 0;
 
     if (isNaN(budget) || isNaN(rate)) return;
 
-    const rows = TERM_OPTIONS.map((months) =>
-      calculateAffordability(budget, rate, months, fee)
-    );
-    setResults(rows);
+    await calculate({
+      monthlyBudget: budget,
+      monthlyRate: rate,
+      months: TERM_OPTIONS,
+      processingFee: fee || undefined,
+    });
   };
 
   return (
@@ -65,12 +101,15 @@ export default function AffordabilityCalculator() {
                 id="aff-budget"
                 type="number"
                 placeholder="e.g. 5000"
-                value={monthlyBudget}
-                onChange={(e) => setMonthlyBudget(e.target.value)}
+                value={form.monthlyBudget}
+                onChange={(e) => setField("monthlyBudget", e.target.value)}
                 required
-                min="0"
-                step="any"
+                min={0}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                The max you can pay each month toward installments
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="aff-rate">Monthly Interest Rate (%)</Label>
@@ -78,12 +117,16 @@ export default function AffordabilityCalculator() {
                 id="aff-rate"
                 type="number"
                 placeholder="e.g. 1.5"
-                value={monthlyRate}
-                onChange={(e) => setMonthlyRate(e.target.value)}
+                value={form.monthlyRate}
+                onChange={(e) => setField("monthlyRate", e.target.value)}
                 required
-                min="0"
-                step="any"
+                min={0}
+                max={100}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                Monthly add-on (flat) interest rate from the bank
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="aff-fee">Processing Fee (optional)</Label>
@@ -91,18 +134,37 @@ export default function AffordabilityCalculator() {
                 id="aff-fee"
                 type="number"
                 placeholder="e.g. 500"
-                value={processingFee}
-                onChange={(e) => setProcessingFee(e.target.value)}
-                min="0"
-                step="any"
+                value={form.processingFee}
+                onChange={(e) => setField("processingFee", e.target.value)}
+                min={0}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                One-time fee deducted from loan proceeds
+              </p>
             </div>
           </div>
-          <Button type="submit">Calculate</Button>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
         {results && (
-          <div className="mt-6">
+          <div className="mt-6" role="region" aria-label="Affordability results">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/components/tools/affordability-calculator.tsx
+++ b/components/tools/affordability-calculator.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  calculateAffordability,
+  type AffordabilityResult,
+} from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+const TERM_OPTIONS = [3, 6, 9, 12, 18, 24, 36];
+
+export default function AffordabilityCalculator() {
+  const [monthlyBudget, setMonthlyBudget] = useState("");
+  const [monthlyRate, setMonthlyRate] = useState("");
+  const [processingFee, setProcessingFee] = useState("");
+  const [results, setResults] = useState<AffordabilityResult[] | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const budget = parseFloat(monthlyBudget);
+    const rate = parseFloat(monthlyRate) / 100;
+    const fee = processingFee ? parseFloat(processingFee) : 0;
+
+    if (isNaN(budget) || isNaN(rate)) return;
+
+    const rows = TERM_OPTIONS.map((months) =>
+      calculateAffordability(budget, rate, months, fee)
+    );
+    setResults(rows);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Affordability Calculator</CardTitle>
+        <CardDescription>
+          Find out the maximum loan amount you can afford based on your monthly
+          budget.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="aff-budget">Monthly Budget</Label>
+              <Input
+                id="aff-budget"
+                type="number"
+                placeholder="e.g. 5000"
+                value={monthlyBudget}
+                onChange={(e) => setMonthlyBudget(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="aff-rate">Monthly Interest Rate (%)</Label>
+              <Input
+                id="aff-rate"
+                type="number"
+                placeholder="e.g. 1.5"
+                value={monthlyRate}
+                onChange={(e) => setMonthlyRate(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="aff-fee">Processing Fee (optional)</Label>
+              <Input
+                id="aff-fee"
+                type="number"
+                placeholder="e.g. 500"
+                value={processingFee}
+                onChange={(e) => setProcessingFee(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+          </div>
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {results && (
+          <div className="mt-6">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Months</TableHead>
+                  <TableHead>Max Affordable Principal</TableHead>
+                  <TableHead>Monthly Payment</TableHead>
+                  <TableHead>Total Payment</TableHead>
+                  <TableHead>Total Interest</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {results.map((row) => (
+                  <TableRow key={row.months}>
+                    <TableCell>{row.months}</TableCell>
+                    <TableCell>{formatCurrency(row.maxPrincipal)}</TableCell>
+                    <TableCell>{formatCurrency(row.monthlyPayment)}</TableCell>
+                    <TableCell>{formatCurrency(row.totalPayment)}</TableCell>
+                    <TableCell>{formatCurrency(row.totalInterest)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/break-even-analyzer.tsx
+++ b/components/tools/break-even-analyzer.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { calculateBreakEven, type BreakEvenResult } from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function BreakEvenAnalyzer() {
+  const [cashPrice, setCashPrice] = useState("");
+  const [installmentPrice, setInstallmentPrice] = useState("");
+  const [monthlyRate, setMonthlyRate] = useState("");
+  const [processingFee, setProcessingFee] = useState("");
+  const [result, setResult] = useState<BreakEvenResult | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const cash = parseFloat(cashPrice);
+    const installment = parseFloat(installmentPrice);
+    const rate = parseFloat(monthlyRate);
+    const fee = parseFloat(processingFee) || 0;
+    if (isNaN(cash) || isNaN(installment) || isNaN(rate)) return;
+    setResult(calculateBreakEven(cash, installment, rate / 100, fee));
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Break-Even Analyzer</CardTitle>
+        <CardDescription>
+          Compare bank installment vs merchant 0% installment to find the break-even point.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="cash-price">Cash Price</Label>
+              <Input
+                id="cash-price"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 50000"
+                value={cashPrice}
+                onChange={(e) => setCashPrice(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="installment-price">Merchant 0% Installment Price</Label>
+              <Input
+                id="installment-price"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 55000"
+                value={installmentPrice}
+                onChange={(e) => setInstallmentPrice(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="be-monthly-rate">Monthly Rate (%)</Label>
+              <Input
+                id="be-monthly-rate"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 1.5"
+                value={monthlyRate}
+                onChange={(e) => setMonthlyRate(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="be-processing-fee">Processing Fee</Label>
+              <Input
+                id="be-processing-fee"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 500"
+                value={processingFee}
+                onChange={(e) => setProcessingFee(e.target.value)}
+              />
+            </div>
+          </div>
+          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+        </form>
+
+        {result && (
+          <div className="space-y-4">
+            {/* Break-even summary */}
+            <div className="rounded-lg border border-primary/30 bg-primary/5 p-4 text-center">
+              {result.breakEvenMonth !== null ? (
+                <>
+                  <p className="text-sm text-muted-foreground">Break-Even Month</p>
+                  <p className="text-3xl font-bold text-primary">Month {result.breakEvenMonth}</p>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Bank installment becomes cheaper starting at {result.breakEvenMonth} months or fewer.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="text-sm text-muted-foreground">No Break-Even Found</p>
+                  <p className="text-lg font-semibold">
+                    The merchant 0% installment is always cheaper within 36 months.
+                  </p>
+                </>
+              )}
+            </div>
+
+            {/* Month-by-month table */}
+            <div>
+              <h4 className="text-sm font-semibold text-muted-foreground mb-2">Month-by-Month Comparison</h4>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Month</TableHead>
+                    <TableHead className="text-right">Bank Total</TableHead>
+                    <TableHead className="text-right">Merchant Total</TableHead>
+                    <TableHead className="text-center">Cheaper</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {result.monthlyData
+                    .filter((_, i) => i < 12 || (i + 1) % 3 === 0)
+                    .map((row) => (
+                      <TableRow
+                        key={row.month}
+                        className={row.month === result.breakEvenMonth ? "bg-primary/10" : ""}
+                      >
+                        <TableCell className="font-medium">
+                          {row.month}
+                          {row.month === result.breakEvenMonth && (
+                            <Badge variant="default" className="ml-2">Break-even</Badge>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">{formatCurrency(row.bankTotal)}</TableCell>
+                        <TableCell className="text-right">{formatCurrency(row.merchantTotal)}</TableCell>
+                        <TableCell className="text-center">
+                          {row.bankCheaper ? (
+                            <Badge variant="default">Bank</Badge>
+                          ) : (
+                            <Badge variant="secondary">Merchant</Badge>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/break-even-analyzer.tsx
+++ b/components/tools/break-even-analyzer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -14,24 +14,60 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { calculateBreakEven, type BreakEvenResult } from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { BreakEvenResult } from "@/lib/calculators";
 import { formatCurrency } from "@/lib/client";
 
-export default function BreakEvenAnalyzer() {
-  const [cashPrice, setCashPrice] = useState("");
-  const [installmentPrice, setInstallmentPrice] = useState("");
-  const [monthlyRate, setMonthlyRate] = useState("");
-  const [processingFee, setProcessingFee] = useState("");
-  const [result, setResult] = useState<BreakEvenResult | null>(null);
+interface FormState {
+  cashPrice: string;
+  installmentPrice: string;
+  monthlyRate: string;
+  processingFee: string;
+  maxMonths: string;
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  cashPrice: "",
+  installmentPrice: "",
+  monthlyRate: "",
+  processingFee: "",
+  maxMonths: "36",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function BreakEvenAnalyzer() {
+  const [form, dispatch] = useReducer(formReducer, initialState);
+  const { data: result, isLoading, error, calculate } = useToolCalculator<BreakEvenResult>("break-even");
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const cash = parseFloat(cashPrice);
-    const installment = parseFloat(installmentPrice);
-    const rate = parseFloat(monthlyRate);
-    const fee = parseFloat(processingFee) || 0;
+    const cash = parseFloat(form.cashPrice);
+    const installment = parseFloat(form.installmentPrice);
+    const rate = parseFloat(form.monthlyRate);
+    const fee = parseFloat(form.processingFee) || 0;
+    const maxMonths = parseInt(form.maxMonths) || 36;
     if (isNaN(cash) || isNaN(installment) || isNaN(rate)) return;
-    setResult(calculateBreakEven(cash, installment, rate / 100, fee));
+    await calculate({
+      cashPrice: cash,
+      installmentPriceZero: installment,
+      monthlyRate: rate / 100,
+      processingFee: fee,
+      maxMonths,
+    });
   };
 
   return (
@@ -40,6 +76,7 @@ export default function BreakEvenAnalyzer() {
         <CardTitle>Break-Even Analyzer</CardTitle>
         <CardDescription>
           Compare bank installment vs merchant 0% installment to find the break-even point.
+          The break-even month is when the bank installment total cost becomes cheaper than the merchant&apos;s 0% plan.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -53,10 +90,13 @@ export default function BreakEvenAnalyzer() {
                 step="0.01"
                 min="0"
                 placeholder="e.g. 50000"
-                value={cashPrice}
-                onChange={(e) => setCashPrice(e.target.value)}
+                value={form.cashPrice}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "cashPrice", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                The cash/SRP price of the item.
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="installment-price">Merchant 0% Installment Price</Label>
@@ -66,10 +106,13 @@ export default function BreakEvenAnalyzer() {
                 step="0.01"
                 min="0"
                 placeholder="e.g. 55000"
-                value={installmentPrice}
-                onChange={(e) => setInstallmentPrice(e.target.value)}
+                value={form.installmentPrice}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "installmentPrice", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                Total price under merchant&apos;s 0% installment plan (often higher than the cash price).
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="be-monthly-rate">Monthly Rate (%)</Label>
@@ -78,11 +121,15 @@ export default function BreakEvenAnalyzer() {
                 type="number"
                 step="0.01"
                 min="0"
+                max="100"
                 placeholder="e.g. 1.5"
-                value={monthlyRate}
-                onChange={(e) => setMonthlyRate(e.target.value)}
+                value={form.monthlyRate}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "monthlyRate", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                The bank&apos;s monthly add-on interest rate for credit card installments.
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="be-processing-fee">Processing Fee</Label>
@@ -92,16 +139,50 @@ export default function BreakEvenAnalyzer() {
                 step="0.01"
                 min="0"
                 placeholder="e.g. 500"
-                value={processingFee}
-                onChange={(e) => setProcessingFee(e.target.value)}
+                value={form.processingFee}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "processingFee", value: e.target.value })}
               />
+              <p className="text-xs text-muted-foreground">
+                One-time processing or service fee charged by the bank (if any).
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="be-max-months">Max Months</Label>
+              <Input
+                id="be-max-months"
+                type="number"
+                step="1"
+                min="1"
+                max="60"
+                placeholder="36"
+                value={form.maxMonths}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "maxMonths", value: e.target.value })}
+              />
+              <p className="text-xs text-muted-foreground">
+                Maximum number of months to compare (default: 36).
+              </p>
             </div>
           </div>
-          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+          <Button type="submit" className="w-full sm:w-auto" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {result && (
-          <div className="space-y-4">
+          <div className="space-y-4" aria-label="Break-even analysis results">
             {/* Break-even summary */}
             <div className="rounded-lg border border-primary/30 bg-primary/5 p-4 text-center">
               {result.breakEvenMonth !== null ? (
@@ -116,7 +197,7 @@ export default function BreakEvenAnalyzer() {
                 <>
                   <p className="text-sm text-muted-foreground">No Break-Even Found</p>
                   <p className="text-lg font-semibold">
-                    The merchant 0% installment is always cheaper within 36 months.
+                    The merchant 0% installment is always cheaper within the comparison period.
                   </p>
                 </>
               )}

--- a/components/tools/car-loan-calculator.tsx
+++ b/components/tools/car-loan-calculator.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { calculateCarLoan, type CarLoanResult } from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function CarLoanCalculator() {
+  const [vehiclePrice, setVehiclePrice] = useState("");
+  const [downPaymentPercent, setDownPaymentPercent] = useState("");
+  const [monthlyRate, setMonthlyRate] = useState("");
+  const [termMonths, setTermMonths] = useState("");
+  const [result, setResult] = useState<CarLoanResult | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const price = parseFloat(vehiclePrice);
+    const dp = parseFloat(downPaymentPercent);
+    const rate = parseFloat(monthlyRate);
+    const months = parseInt(termMonths);
+    if (isNaN(price) || isNaN(dp) || isNaN(rate) || isNaN(months) || months <= 0) return;
+    setResult(calculateCarLoan(price, dp, rate / 100, months));
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Car Loan Calculator</CardTitle>
+        <CardDescription>
+          Estimate your monthly car loan payment, total interest, and chattel mortgage fee.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="vehicle-price">Vehicle Price</Label>
+              <Input
+                id="vehicle-price"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 1000000"
+                value={vehiclePrice}
+                onChange={(e) => setVehiclePrice(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cl-down-payment">Down Payment (%)</Label>
+              <Input
+                id="cl-down-payment"
+                type="number"
+                step="0.1"
+                min="0"
+                max="100"
+                placeholder="e.g. 20"
+                value={downPaymentPercent}
+                onChange={(e) => setDownPaymentPercent(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cl-monthly-rate">Monthly Rate (%)</Label>
+              <Input
+                id="cl-monthly-rate"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 1.2"
+                value={monthlyRate}
+                onChange={(e) => setMonthlyRate(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cl-term">Term (Months)</Label>
+              <Input
+                id="cl-term"
+                type="number"
+                min="1"
+                placeholder="e.g. 60"
+                value={termMonths}
+                onChange={(e) => setTermMonths(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+        </form>
+
+        {result && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-muted-foreground">Loan Breakdown</h4>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Item</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Vehicle Price</TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCurrency(result.vehiclePrice)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell className="pl-6 text-muted-foreground">Down Payment</TableCell>
+                  <TableCell className="text-right font-medium text-orange-600 dark:text-orange-400">
+                    -{formatCurrency(result.downPayment)}
+                  </TableCell>
+                </TableRow>
+                <TableRow className="border-t-2">
+                  <TableCell className="font-medium">Loan Amount</TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCurrency(result.loanAmount)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Chattel Mortgage Fee</TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCurrency(result.chattelMortgageFee)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Total Interest</TableCell>
+                  <TableCell className="text-right font-medium text-orange-600 dark:text-orange-400">
+                    {formatCurrency(result.totalInterest)}
+                  </TableCell>
+                </TableRow>
+                <TableRow className="border-t-2">
+                  <TableCell className="font-medium">Total Cost</TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCurrency(result.totalPayment)}
+                  </TableCell>
+                </TableRow>
+                <TableRow className="bg-primary/5">
+                  <TableCell className="font-bold text-primary">Monthly Payment</TableCell>
+                  <TableCell className="text-right text-xl font-bold text-primary">
+                    {formatCurrency(result.monthlyPayment)}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/car-loan-calculator.tsx
+++ b/components/tools/car-loan-calculator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -13,24 +13,56 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { calculateCarLoan, type CarLoanResult } from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { CarLoanResult } from "@/lib/calculators";
 import { formatCurrency } from "@/lib/client";
 
-export default function CarLoanCalculator() {
-  const [vehiclePrice, setVehiclePrice] = useState("");
-  const [downPaymentPercent, setDownPaymentPercent] = useState("");
-  const [monthlyRate, setMonthlyRate] = useState("");
-  const [termMonths, setTermMonths] = useState("");
-  const [result, setResult] = useState<CarLoanResult | null>(null);
+interface FormState {
+  vehiclePrice: string;
+  downPaymentPercent: string;
+  monthlyRate: string;
+  termMonths: string;
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  vehiclePrice: "",
+  downPaymentPercent: "",
+  monthlyRate: "",
+  termMonths: "",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function CarLoanCalculator() {
+  const [form, dispatch] = useReducer(formReducer, initialState);
+  const { data: result, isLoading, error, calculate } = useToolCalculator<CarLoanResult>("car-loan");
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const price = parseFloat(vehiclePrice);
-    const dp = parseFloat(downPaymentPercent);
-    const rate = parseFloat(monthlyRate);
-    const months = parseInt(termMonths);
+    const price = parseFloat(form.vehiclePrice);
+    const dp = parseFloat(form.downPaymentPercent);
+    const rate = parseFloat(form.monthlyRate);
+    const months = parseInt(form.termMonths);
     if (isNaN(price) || isNaN(dp) || isNaN(rate) || isNaN(months) || months <= 0) return;
-    setResult(calculateCarLoan(price, dp, rate / 100, months));
+    await calculate({
+      vehiclePrice: price,
+      downPaymentPercent: dp,
+      monthlyRate: rate / 100,
+      months,
+    });
   };
 
   return (
@@ -52,10 +84,13 @@ export default function CarLoanCalculator() {
                 step="0.01"
                 min="0"
                 placeholder="e.g. 1000000"
-                value={vehiclePrice}
-                onChange={(e) => setVehiclePrice(e.target.value)}
+                value={form.vehiclePrice}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "vehiclePrice", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                The total selling price of the vehicle.
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="cl-down-payment">Down Payment (%)</Label>
@@ -66,10 +101,13 @@ export default function CarLoanCalculator() {
                 min="0"
                 max="100"
                 placeholder="e.g. 20"
-                value={downPaymentPercent}
-                onChange={(e) => setDownPaymentPercent(e.target.value)}
+                value={form.downPaymentPercent}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "downPaymentPercent", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                Typically 20-30% for auto loans in PH. A higher down payment reduces your monthly amortization.
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="cl-monthly-rate">Monthly Rate (%)</Label>
@@ -78,30 +116,54 @@ export default function CarLoanCalculator() {
                 type="number"
                 step="0.01"
                 min="0"
+                max="100"
                 placeholder="e.g. 1.2"
-                value={monthlyRate}
-                onChange={(e) => setMonthlyRate(e.target.value)}
+                value={form.monthlyRate}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "monthlyRate", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                The monthly add-on interest rate from the bank or financing company.
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="cl-term">Term (Months)</Label>
               <Input
                 id="cl-term"
                 type="number"
+                step="1"
                 min="1"
+                max="84"
                 placeholder="e.g. 60"
-                value={termMonths}
-                onChange={(e) => setTermMonths(e.target.value)}
+                value={form.termMonths}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "termMonths", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                Loan repayment period. Common terms are 36, 48, or 60 months.
+              </p>
             </div>
           </div>
-          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+          <Button type="submit" className="w-full sm:w-auto" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {result && (
-          <div className="space-y-4">
+          <div className="space-y-4" aria-label="Car loan breakdown results">
             <h4 className="text-sm font-semibold text-muted-foreground">Loan Breakdown</h4>
             <Table>
               <TableHeader>
@@ -130,7 +192,12 @@ export default function CarLoanCalculator() {
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell>Chattel Mortgage Fee</TableCell>
+                  <TableCell>
+                    Chattel Mortgage Fee
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      ~1.5% of loan amount, registered with LTO
+                    </p>
+                  </TableCell>
                   <TableCell className="text-right font-medium">
                     {formatCurrency(result.chattelMortgageFee)}
                   </TableCell>

--- a/components/tools/credit-card-payoff.tsx
+++ b/components/tools/credit-card-payoff.tsx
@@ -1,38 +1,64 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { calculateCreditCardPayoff, type CreditCardPayoffResult } from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { CreditCardPayoffResult } from "@/lib/calculators";
 import { formatCurrency } from "@/lib/client";
 
-export default function CreditCardPayoff() {
-  const [balance, setBalance] = useState("");
-  const [annualRate, setAnnualRate] = useState("");
-  const [minPaymentPercent, setMinPaymentPercent] = useState("3");
-  const [minFloor, setMinFloor] = useState("500");
-  const [fixedPayment, setFixedPayment] = useState("");
-  const [result, setResult] = useState<CreditCardPayoffResult | null>(null);
+interface FormState {
+  balance: string;
+  annualRate: string;
+  minPaymentPercent: string;
+  minFloor: string;
+  fixedPayment: string;
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  balance: "",
+  annualRate: "",
+  minPaymentPercent: "3",
+  minFloor: "500",
+  fixedPayment: "",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function CreditCardPayoff() {
+  const [form, dispatch] = useReducer(formReducer, initialState);
+  const { data: result, isLoading, error, calculate } = useToolCalculator<CreditCardPayoffResult>("credit-card-payoff");
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const bal = parseFloat(balance);
-    const rate = parseFloat(annualRate);
-    const minPct = parseFloat(minPaymentPercent);
-    const floor = parseFloat(minFloor);
-    const fixed = parseFloat(fixedPayment);
+    const bal = parseFloat(form.balance);
+    const rate = parseFloat(form.annualRate);
+    const minPct = parseFloat(form.minPaymentPercent);
+    const floor = parseFloat(form.minFloor);
+    const fixed = parseFloat(form.fixedPayment);
     if (isNaN(bal) || isNaN(rate) || bal <= 0) return;
-    setResult(
-      calculateCreditCardPayoff(
-        bal,
-        rate / 100,
-        (isNaN(minPct) ? 3 : minPct) / 100,
-        isNaN(floor) ? 500 : floor,
-        isNaN(fixed) ? 0 : fixed
-      )
-    );
+    await calculate({
+      balance: bal,
+      annualRate: rate / 100,
+      minimumPaymentPercent: (isNaN(minPct) ? 3 : minPct) / 100,
+      minimumPaymentFloor: isNaN(floor) ? 500 : floor,
+      fixedPayment: isNaN(fixed) ? 0 : fixed,
+    });
   };
 
   return (
@@ -52,12 +78,15 @@ export default function CreditCardPayoff() {
                 id="cc-balance"
                 type="number"
                 step="0.01"
-                min="0"
+                min="1"
                 placeholder="e.g. 50000"
-                value={balance}
-                onChange={(e) => setBalance(e.target.value)}
+                value={form.balance}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "balance", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                Your current outstanding credit card balance.
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="cc-annual-rate">Annual Interest Rate (%)</Label>
@@ -66,11 +95,15 @@ export default function CreditCardPayoff() {
                 type="number"
                 step="0.01"
                 min="0"
+                max="100"
                 placeholder="e.g. 24"
-                value={annualRate}
-                onChange={(e) => setAnnualRate(e.target.value)}
+                value={form.annualRate}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "annualRate", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                The annual interest rate on your credit card (typically 24-36% in PH).
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="cc-min-pct">Minimum Payment (%)</Label>
@@ -79,22 +112,29 @@ export default function CreditCardPayoff() {
                 type="number"
                 step="0.1"
                 min="0"
+                max="100"
                 placeholder="3"
-                value={minPaymentPercent}
-                onChange={(e) => setMinPaymentPercent(e.target.value)}
+                value={form.minPaymentPercent}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "minPaymentPercent", value: e.target.value })}
               />
+              <p className="text-xs text-muted-foreground">
+                Percentage of outstanding balance as minimum payment (typically 3%).
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="cc-min-floor">Minimum Floor Amount</Label>
               <Input
                 id="cc-min-floor"
                 type="number"
-                step="0.01"
+                step="1"
                 min="0"
                 placeholder="500"
-                value={minFloor}
-                onChange={(e) => setMinFloor(e.target.value)}
+                value={form.minFloor}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "minFloor", value: e.target.value })}
               />
+              <p className="text-xs text-muted-foreground">
+                Minimum payment floor amount (typically &#8369;500). You pay at least this much even if the percentage is lower.
+              </p>
             </div>
             <div className="space-y-2 sm:col-span-2">
               <Label htmlFor="cc-fixed">Fixed Monthly Payment</Label>
@@ -104,16 +144,34 @@ export default function CreditCardPayoff() {
                 step="0.01"
                 min="0"
                 placeholder="e.g. 5000"
-                value={fixedPayment}
-                onChange={(e) => setFixedPayment(e.target.value)}
+                value={form.fixedPayment}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "fixedPayment", value: e.target.value })}
               />
+              <p className="text-xs text-muted-foreground">
+                A fixed amount you plan to pay monthly to pay off faster. Leave blank to auto-calculate as 2x the minimum.
+              </p>
             </div>
           </div>
-          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+          <Button type="submit" className="w-full sm:w-auto" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {result && (
-          <div className="space-y-4">
+          <div className="space-y-4" aria-label="Payoff comparison results">
             <h4 className="text-sm font-semibold text-muted-foreground">Payoff Comparison</h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {/* Minimum Payment */}

--- a/components/tools/credit-card-payoff.tsx
+++ b/components/tools/credit-card-payoff.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { calculateCreditCardPayoff, type CreditCardPayoffResult } from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function CreditCardPayoff() {
+  const [balance, setBalance] = useState("");
+  const [annualRate, setAnnualRate] = useState("");
+  const [minPaymentPercent, setMinPaymentPercent] = useState("3");
+  const [minFloor, setMinFloor] = useState("500");
+  const [fixedPayment, setFixedPayment] = useState("");
+  const [result, setResult] = useState<CreditCardPayoffResult | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const bal = parseFloat(balance);
+    const rate = parseFloat(annualRate);
+    const minPct = parseFloat(minPaymentPercent);
+    const floor = parseFloat(minFloor);
+    const fixed = parseFloat(fixedPayment);
+    if (isNaN(bal) || isNaN(rate) || bal <= 0) return;
+    setResult(
+      calculateCreditCardPayoff(
+        bal,
+        rate / 100,
+        (isNaN(minPct) ? 3 : minPct) / 100,
+        isNaN(floor) ? 500 : floor,
+        isNaN(fixed) ? 0 : fixed
+      )
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Credit Card Payoff Calculator</CardTitle>
+        <CardDescription>
+          Compare minimum payments vs fixed monthly payments and see how much you can save.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="cc-balance">Outstanding Balance</Label>
+              <Input
+                id="cc-balance"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 50000"
+                value={balance}
+                onChange={(e) => setBalance(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cc-annual-rate">Annual Interest Rate (%)</Label>
+              <Input
+                id="cc-annual-rate"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 24"
+                value={annualRate}
+                onChange={(e) => setAnnualRate(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cc-min-pct">Minimum Payment (%)</Label>
+              <Input
+                id="cc-min-pct"
+                type="number"
+                step="0.1"
+                min="0"
+                placeholder="3"
+                value={minPaymentPercent}
+                onChange={(e) => setMinPaymentPercent(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cc-min-floor">Minimum Floor Amount</Label>
+              <Input
+                id="cc-min-floor"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="500"
+                value={minFloor}
+                onChange={(e) => setMinFloor(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2 sm:col-span-2">
+              <Label htmlFor="cc-fixed">Fixed Monthly Payment</Label>
+              <Input
+                id="cc-fixed"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 5000"
+                value={fixedPayment}
+                onChange={(e) => setFixedPayment(e.target.value)}
+              />
+            </div>
+          </div>
+          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+        </form>
+
+        {result && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-muted-foreground">Payoff Comparison</h4>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {/* Minimum Payment */}
+              <div className="rounded-lg border p-4 space-y-3">
+                <h5 className="font-semibold text-sm">Minimum Payments</h5>
+                <div className="space-y-2">
+                  <div className="flex justify-between">
+                    <span className="text-sm text-muted-foreground">Months to Payoff</span>
+                    <span className="font-medium">{result.minimumPaymentMonths}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-sm text-muted-foreground">Total Paid</span>
+                    <span className="font-medium">{formatCurrency(result.minimumPaymentTotal)}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-sm text-muted-foreground">Total Interest</span>
+                    <span className="font-medium text-orange-600 dark:text-orange-400">
+                      {formatCurrency(result.minimumPaymentInterest)}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Fixed Payment */}
+              <div className="rounded-lg border border-primary/30 bg-primary/5 p-4 space-y-3">
+                <h5 className="font-semibold text-sm">Fixed Payments</h5>
+                <div className="space-y-2">
+                  <div className="flex justify-between">
+                    <span className="text-sm text-muted-foreground">Months to Payoff</span>
+                    <span className="font-medium">{result.fixedPaymentMonths}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-sm text-muted-foreground">Total Paid</span>
+                    <span className="font-medium">{formatCurrency(result.fixedPaymentTotal)}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-sm text-muted-foreground">Total Interest</span>
+                    <span className="font-medium text-orange-600 dark:text-orange-400">
+                      {formatCurrency(result.fixedPaymentInterest)}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Savings highlight */}
+            {result.interestSaved > 0 && (
+              <div className="rounded-lg border border-green-500/30 bg-green-500/10 p-4 text-center">
+                <p className="text-sm text-muted-foreground">By using fixed payments, you save</p>
+                <p className="text-2xl font-bold text-green-600 dark:text-green-400">
+                  {formatCurrency(result.interestSaved)}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  in interest and pay off {result.timeSaved} months sooner
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/debt-planner.tsx
+++ b/components/tools/debt-planner.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  calculateDebtPayoff,
+  type DebtItem,
+  type DebtPayoffResult,
+} from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+interface DebtFormItem {
+  name: string;
+  balance: string;
+  monthlyRate: string;
+  minimumPayment: string;
+}
+
+const emptyDebt = (): DebtFormItem => ({
+  name: "",
+  balance: "",
+  monthlyRate: "",
+  minimumPayment: "",
+});
+
+export default function DebtPlanner() {
+  const [debts, setDebts] = useState<DebtFormItem[]>([emptyDebt()]);
+  const [extraPayment, setExtraPayment] = useState("");
+  const [method, setMethod] = useState<"snowball" | "avalanche">("snowball");
+  const [results, setResults] = useState<DebtPayoffResult | null>(null);
+
+  const addDebt = () => {
+    setDebts([...debts, emptyDebt()]);
+  };
+
+  const removeDebt = (index: number) => {
+    if (debts.length <= 1) return;
+    setDebts(debts.filter((_, i) => i !== index));
+  };
+
+  const updateDebt = (
+    index: number,
+    field: keyof DebtFormItem,
+    value: string
+  ) => {
+    const updated = [...debts];
+    updated[index] = { ...updated[index], [field]: value };
+    setDebts(updated);
+  };
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const extra = parseFloat(extraPayment) || 0;
+
+    const debtItems: DebtItem[] = debts
+      .filter(
+        (d) =>
+          d.name &&
+          parseFloat(d.balance) > 0 &&
+          parseFloat(d.monthlyRate) >= 0 &&
+          parseFloat(d.minimumPayment) > 0
+      )
+      .map((d) => ({
+        name: d.name,
+        balance: parseFloat(d.balance),
+        monthlyRate: parseFloat(d.monthlyRate) / 100,
+        minimumPayment: parseFloat(d.minimumPayment),
+      }));
+
+    if (debtItems.length === 0) return;
+
+    const result = calculateDebtPayoff(debtItems, extra, method);
+    setResults(result);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Debt Payoff Planner</CardTitle>
+        <CardDescription>
+          Compare snowball and avalanche methods to find the fastest way to
+          become debt-free.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="space-y-4">
+            {debts.map((debt, index) => (
+              <div
+                key={index}
+                className="grid grid-cols-1 gap-3 rounded-md border p-3 sm:grid-cols-5"
+              >
+                <div className="space-y-2">
+                  <Label htmlFor={`debt-name-${index}`}>Debt Name</Label>
+                  <Input
+                    id={`debt-name-${index}`}
+                    type="text"
+                    placeholder="e.g. Credit Card"
+                    value={debt.name}
+                    onChange={(e) => updateDebt(index, "name", e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`debt-balance-${index}`}>Balance</Label>
+                  <Input
+                    id={`debt-balance-${index}`}
+                    type="number"
+                    placeholder="e.g. 50000"
+                    value={debt.balance}
+                    onChange={(e) =>
+                      updateDebt(index, "balance", e.target.value)
+                    }
+                    required
+                    min="0"
+                    step="any"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`debt-rate-${index}`}>Monthly Rate (%)</Label>
+                  <Input
+                    id={`debt-rate-${index}`}
+                    type="number"
+                    placeholder="e.g. 2"
+                    value={debt.monthlyRate}
+                    onChange={(e) =>
+                      updateDebt(index, "monthlyRate", e.target.value)
+                    }
+                    required
+                    min="0"
+                    step="any"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`debt-min-${index}`}>Min. Payment</Label>
+                  <Input
+                    id={`debt-min-${index}`}
+                    type="number"
+                    placeholder="e.g. 2000"
+                    value={debt.minimumPayment}
+                    onChange={(e) =>
+                      updateDebt(index, "minimumPayment", e.target.value)
+                    }
+                    required
+                    min="0"
+                    step="any"
+                  />
+                </div>
+                <div className="flex items-end">
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => removeDebt(index)}
+                    disabled={debts.length <= 1}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <Button type="button" variant="outline" size="sm" onClick={addDebt}>
+            + Add Debt
+          </Button>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="dp-extra">Extra Monthly Payment</Label>
+              <Input
+                id="dp-extra"
+                type="number"
+                placeholder="e.g. 1000"
+                value={extraPayment}
+                onChange={(e) => setExtraPayment(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Payoff Method</Label>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant={method === "snowball" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setMethod("snowball")}
+                >
+                  Snowball
+                </Button>
+                <Button
+                  type="button"
+                  variant={method === "avalanche" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setMethod("avalanche")}
+                >
+                  Avalanche
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {results && (
+          <div className="mt-6 space-y-4">
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Method</p>
+                <p className="text-lg font-semibold capitalize">
+                  {results.method}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Total Months</p>
+                <p className="text-lg font-semibold">{results.totalMonths}</p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Total Paid</p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.totalPaid)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Total Interest</p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.totalInterest)}
+                </p>
+              </div>
+            </div>
+
+            <div>
+              <p className="mb-2 text-sm font-medium">Payoff Order</p>
+              <ol className="list-inside list-decimal space-y-1 text-sm">
+                {results.order.map((name, i) => (
+                  <li key={i}>{name}</li>
+                ))}
+              </ol>
+            </div>
+
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Month</TableHead>
+                  {results.schedule[0]?.payments.map((p) => (
+                    <TableHead key={p.name}>{p.name}</TableHead>
+                  ))}
+                  <TableHead>Total Remaining</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {results.schedule
+                  .filter(
+                    (row, i) =>
+                      i < 12 ||
+                      i === results.schedule.length - 1 ||
+                      row.totalRemaining === 0
+                  )
+                  .map((row) => (
+                    <TableRow key={row.month}>
+                      <TableCell>{row.month}</TableCell>
+                      {row.payments.map((p) => (
+                        <TableCell key={p.name}>
+                          {formatCurrency(p.remaining)}
+                        </TableCell>
+                      ))}
+                      <TableCell>
+                        {formatCurrency(row.totalRemaining)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/debt-planner.tsx
+++ b/components/tools/debt-planner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer, useCallback } from "react";
 import {
   Card,
   CardHeader,
@@ -19,76 +19,108 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  calculateDebtPayoff,
-  type DebtItem,
-  type DebtPayoffResult,
-} from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { DebtPayoffResult } from "@/lib/calculators";
 import { formatCurrency } from "@/lib/client";
 
 interface DebtFormItem {
+  id: string;
   name: string;
   balance: string;
   monthlyRate: string;
   minimumPayment: string;
 }
 
-const emptyDebt = (): DebtFormItem => ({
+const createDebt = (): DebtFormItem => ({
+  id: crypto.randomUUID(),
   name: "",
   balance: "",
   monthlyRate: "",
   minimumPayment: "",
 });
 
+interface FormState {
+  debts: DebtFormItem[];
+  extraPayment: string;
+  method: "snowball" | "avalanche";
+}
+
+type FormAction =
+  | { type: "SET_FIELD"; field: "extraPayment"; value: string }
+  | { type: "SET_METHOD"; value: "snowball" | "avalanche" }
+  | { type: "UPDATE_DEBT"; id: string; field: keyof Omit<DebtFormItem, "id">; value: string }
+  | { type: "ADD_DEBT" }
+  | { type: "REMOVE_DEBT"; id: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  debts: [createDebt()],
+  extraPayment: "",
+  method: "snowball",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "SET_METHOD":
+      return { ...state, method: action.value };
+    case "UPDATE_DEBT":
+      return {
+        ...state,
+        debts: state.debts.map((d) =>
+          d.id === action.id ? { ...d, [action.field]: action.value } : d
+        ),
+      };
+    case "ADD_DEBT":
+      return { ...state, debts: [...state.debts, createDebt()] };
+    case "REMOVE_DEBT":
+      return { ...state, debts: state.debts.filter((d) => d.id !== action.id) };
+    case "RESET":
+      return { ...initialState, debts: [createDebt()] };
+  }
+}
+
 export default function DebtPlanner() {
-  const [debts, setDebts] = useState<DebtFormItem[]>([emptyDebt()]);
-  const [extraPayment, setExtraPayment] = useState("");
-  const [method, setMethod] = useState<"snowball" | "avalanche">("snowball");
-  const [results, setResults] = useState<DebtPayoffResult | null>(null);
+  const [form, dispatch] = useReducer(formReducer, initialState);
+  const {
+    data: results,
+    isLoading,
+    error,
+    calculate,
+  } = useToolCalculator<DebtPayoffResult>("debt-planner");
 
-  const addDebt = () => {
-    setDebts([...debts, emptyDebt()]);
-  };
+  const handleCalculate = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
 
-  const removeDebt = (index: number) => {
-    if (debts.length <= 1) return;
-    setDebts(debts.filter((_, i) => i !== index));
-  };
+      const debts = form.debts
+        .filter(
+          (d) =>
+            d.name &&
+            parseFloat(d.balance) > 0 &&
+            parseFloat(d.monthlyRate) >= 0 &&
+            parseFloat(d.minimumPayment) > 0
+        )
+        .map((d) => ({
+          name: d.name,
+          balance: parseFloat(d.balance),
+          monthlyRate: parseFloat(d.monthlyRate) / 100,
+          minimumPayment: parseFloat(d.minimumPayment),
+        }));
 
-  const updateDebt = (
-    index: number,
-    field: keyof DebtFormItem,
-    value: string
-  ) => {
-    const updated = [...debts];
-    updated[index] = { ...updated[index], [field]: value };
-    setDebts(updated);
-  };
+      if (debts.length === 0) return;
 
-  const handleCalculate = (e: React.FormEvent) => {
-    e.preventDefault();
-    const extra = parseFloat(extraPayment) || 0;
-
-    const debtItems: DebtItem[] = debts
-      .filter(
-        (d) =>
-          d.name &&
-          parseFloat(d.balance) > 0 &&
-          parseFloat(d.monthlyRate) >= 0 &&
-          parseFloat(d.minimumPayment) > 0
-      )
-      .map((d) => ({
-        name: d.name,
-        balance: parseFloat(d.balance),
-        monthlyRate: parseFloat(d.monthlyRate) / 100,
-        minimumPayment: parseFloat(d.minimumPayment),
-      }));
-
-    if (debtItems.length === 0) return;
-
-    const result = calculateDebtPayoff(debtItems, extra, method);
-    setResults(result);
-  };
+      await calculate({
+        debts,
+        extraPayment: parseFloat(form.extraPayment) || 0,
+        method: form.method,
+      });
+    },
+    [form, calculate]
+  );
 
   return (
     <Card>
@@ -102,74 +134,114 @@ export default function DebtPlanner() {
       <CardContent>
         <form onSubmit={handleCalculate} className="space-y-4">
           <div className="space-y-4">
-            {debts.map((debt, index) => (
+            {form.debts.map((debt) => (
               <div
-                key={index}
+                key={debt.id}
                 className="grid grid-cols-1 gap-3 rounded-md border p-3 sm:grid-cols-5"
               >
                 <div className="space-y-2">
-                  <Label htmlFor={`debt-name-${index}`}>Debt Name</Label>
+                  <Label htmlFor={`debt-name-${debt.id}`}>Debt Name</Label>
                   <Input
-                    id={`debt-name-${index}`}
+                    id={`debt-name-${debt.id}`}
                     type="text"
                     placeholder="e.g. Credit Card"
                     value={debt.name}
-                    onChange={(e) => updateDebt(index, "name", e.target.value)}
+                    onChange={(e) =>
+                      dispatch({
+                        type: "UPDATE_DEBT",
+                        id: debt.id,
+                        field: "name",
+                        value: e.target.value,
+                      })
+                    }
                     required
                   />
+                  <p className="text-xs text-muted-foreground">
+                    A label to identify this debt
+                  </p>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor={`debt-balance-${index}`}>Balance</Label>
+                  <Label htmlFor={`debt-balance-${debt.id}`}>Balance</Label>
                   <Input
-                    id={`debt-balance-${index}`}
+                    id={`debt-balance-${debt.id}`}
                     type="number"
                     placeholder="e.g. 50000"
                     value={debt.balance}
                     onChange={(e) =>
-                      updateDebt(index, "balance", e.target.value)
+                      dispatch({
+                        type: "UPDATE_DEBT",
+                        id: debt.id,
+                        field: "balance",
+                        value: e.target.value,
+                      })
                     }
                     required
-                    min="0"
-                    step="any"
+                    min="0.01"
+                    step="0.01"
                   />
+                  <p className="text-xs text-muted-foreground">
+                    Current outstanding balance
+                  </p>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor={`debt-rate-${index}`}>Monthly Rate (%)</Label>
+                  <Label htmlFor={`debt-rate-${debt.id}`}>
+                    Monthly Rate (%)
+                  </Label>
                   <Input
-                    id={`debt-rate-${index}`}
+                    id={`debt-rate-${debt.id}`}
                     type="number"
                     placeholder="e.g. 2"
                     value={debt.monthlyRate}
                     onChange={(e) =>
-                      updateDebt(index, "monthlyRate", e.target.value)
+                      dispatch({
+                        type: "UPDATE_DEBT",
+                        id: debt.id,
+                        field: "monthlyRate",
+                        value: e.target.value,
+                      })
                     }
                     required
                     min="0"
-                    step="any"
+                    max="100"
+                    step="0.01"
                   />
+                  <p className="text-xs text-muted-foreground">
+                    Monthly interest rate applied to balance
+                  </p>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor={`debt-min-${index}`}>Min. Payment</Label>
+                  <Label htmlFor={`debt-min-${debt.id}`}>Min. Payment</Label>
                   <Input
-                    id={`debt-min-${index}`}
+                    id={`debt-min-${debt.id}`}
                     type="number"
                     placeholder="e.g. 2000"
                     value={debt.minimumPayment}
                     onChange={(e) =>
-                      updateDebt(index, "minimumPayment", e.target.value)
+                      dispatch({
+                        type: "UPDATE_DEBT",
+                        id: debt.id,
+                        field: "minimumPayment",
+                        value: e.target.value,
+                      })
                     }
                     required
-                    min="0"
-                    step="any"
+                    min="1"
+                    step="0.01"
                   />
+                  <p className="text-xs text-muted-foreground">
+                    Required minimum monthly payment
+                  </p>
                 </div>
                 <div className="flex items-end">
                   <Button
                     type="button"
                     variant="destructive"
                     size="sm"
-                    onClick={() => removeDebt(index)}
-                    disabled={debts.length <= 1}
+                    onClick={() =>
+                      dispatch({ type: "REMOVE_DEBT", id: debt.id })
+                    }
+                    disabled={form.debts.length <= 1}
+                    aria-label={`Remove ${debt.name || "debt"}`}
                   >
                     Remove
                   </Button>
@@ -178,7 +250,12 @@ export default function DebtPlanner() {
             ))}
           </div>
 
-          <Button type="button" variant="outline" size="sm" onClick={addDebt}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => dispatch({ type: "ADD_DEBT" })}
+          >
             + Add Debt
           </Button>
 
@@ -189,40 +266,74 @@ export default function DebtPlanner() {
                 id="dp-extra"
                 type="number"
                 placeholder="e.g. 1000"
-                value={extraPayment}
-                onChange={(e) => setExtraPayment(e.target.value)}
+                value={form.extraPayment}
+                onChange={(e) =>
+                  dispatch({
+                    type: "SET_FIELD",
+                    field: "extraPayment",
+                    value: e.target.value,
+                  })
+                }
                 min="0"
-                step="any"
+                step="0.01"
               />
+              <p className="text-xs text-muted-foreground">
+                Additional amount above minimums applied to priority debt
+              </p>
             </div>
             <div className="space-y-2">
-              <Label>Payoff Method</Label>
-              <div className="flex gap-2">
+              <Label htmlFor="dp-method">Payoff Method</Label>
+              <div id="dp-method" className="flex gap-2">
                 <Button
                   type="button"
-                  variant={method === "snowball" ? "default" : "outline"}
+                  variant={form.method === "snowball" ? "default" : "outline"}
                   size="sm"
-                  onClick={() => setMethod("snowball")}
+                  onClick={() =>
+                    dispatch({ type: "SET_METHOD", value: "snowball" })
+                  }
+                  aria-pressed={form.method === "snowball"}
                 >
                   Snowball
                 </Button>
                 <Button
                   type="button"
-                  variant={method === "avalanche" ? "default" : "outline"}
+                  variant={form.method === "avalanche" ? "default" : "outline"}
                   size="sm"
-                  onClick={() => setMethod("avalanche")}
+                  onClick={() =>
+                    dispatch({ type: "SET_METHOD", value: "avalanche" })
+                  }
+                  aria-pressed={form.method === "avalanche"}
                 >
                   Avalanche
                 </Button>
               </div>
+              <p className="text-xs text-muted-foreground">
+                Snowball pays smallest balance first for quick wins. Avalanche
+                targets highest interest rate first to minimize total interest.
+              </p>
             </div>
           </div>
 
-          <Button type="submit">Calculate</Button>
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
+        {error && (
+          <Alert variant="destructive" className="mt-4">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {results && (
-          <div className="mt-6 space-y-4">
+          <div className="mt-6 space-y-4" aria-label="Debt payoff results">
             <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
               <div className="rounded-md border p-3">
                 <p className="text-sm text-muted-foreground">Method</p>
@@ -251,8 +362,8 @@ export default function DebtPlanner() {
             <div>
               <p className="mb-2 text-sm font-medium">Payoff Order</p>
               <ol className="list-inside list-decimal space-y-1 text-sm">
-                {results.order.map((name, i) => (
-                  <li key={i}>{name}</li>
+                {results.order.map((name) => (
+                  <li key={name}>{name}</li>
                 ))}
               </ol>
             </div>

--- a/components/tools/early-payoff-calculator.tsx
+++ b/components/tools/early-payoff-calculator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer, useCallback } from "react";
 import {
   Card,
   CardHeader,
@@ -11,32 +11,73 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import {
-  calculateEarlyPayoff,
-  type EarlyPayoffResult,
-} from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { EarlyPayoffResult } from "@/lib/calculators";
 import { formatCurrency } from "@/lib/client";
 
-export default function EarlyPayoffCalculator() {
-  const [principal, setPrincipal] = useState("");
-  const [monthlyRate, setMonthlyRate] = useState("");
-  const [originalTerm, setOriginalTerm] = useState("");
-  const [extraPayment, setExtraPayment] = useState("");
-  const [processingFee, setProcessingFee] = useState("");
-  const [result, setResult] = useState<EarlyPayoffResult | null>(null);
+interface FormState {
+  principal: string;
+  monthlyRate: string;
+  originalTerm: string;
+  extraPayment: string;
+  processingFee: string;
+}
 
-  const handleCalculate = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  principal: "",
+  monthlyRate: "",
+  originalTerm: "",
+  extraPayment: "",
+  processingFee: "",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function EarlyPayoffCalculator() {
+  const [form, formDispatch] = useReducer(formReducer, initialState);
+  const setField = useCallback(
+    (field: keyof FormState, value: string) =>
+      formDispatch({ type: "SET_FIELD", field, value }),
+    []
+  );
+
+  const {
+    data: result,
+    isLoading,
+    error,
+    calculate,
+  } = useToolCalculator<EarlyPayoffResult>("early-payoff");
+
+  const handleCalculate = async (e: React.FormEvent) => {
     e.preventDefault();
-    const p = parseFloat(principal);
-    const rate = parseFloat(monthlyRate) / 100;
-    const term = parseInt(originalTerm, 10);
-    const extra = parseFloat(extraPayment);
-    const fee = processingFee ? parseFloat(processingFee) : 0;
+    const p = parseFloat(form.principal);
+    const rate = parseFloat(form.monthlyRate) / 100;
+    const term = parseInt(form.originalTerm, 10);
+    const extra = parseFloat(form.extraPayment);
+    const fee = form.processingFee ? parseFloat(form.processingFee) : 0;
 
     if (isNaN(p) || isNaN(rate) || isNaN(term) || isNaN(extra)) return;
 
-    const res = calculateEarlyPayoff(p, rate, term, extra, fee);
-    setResult(res);
+    await calculate({
+      principal: p,
+      monthlyRate: rate,
+      originalMonths: term,
+      extraPayment: extra,
+      processingFee: fee,
+    });
   };
 
   return (
@@ -57,12 +98,15 @@ export default function EarlyPayoffCalculator() {
                 id="ep-principal"
                 type="number"
                 placeholder="e.g. 100000"
-                value={principal}
-                onChange={(e) => setPrincipal(e.target.value)}
+                value={form.principal}
+                onChange={(e) => setField("principal", e.target.value)}
                 required
-                min="0"
-                step="any"
+                min={0}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                Original loan amount before interest
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="ep-rate">Monthly Rate (%)</Label>
@@ -70,12 +114,16 @@ export default function EarlyPayoffCalculator() {
                 id="ep-rate"
                 type="number"
                 placeholder="e.g. 1.5"
-                value={monthlyRate}
-                onChange={(e) => setMonthlyRate(e.target.value)}
+                value={form.monthlyRate}
+                onChange={(e) => setField("monthlyRate", e.target.value)}
                 required
-                min="0"
-                step="any"
+                min={0}
+                max={100}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                Monthly add-on (flat) interest rate on the loan
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="ep-term">Original Term (months)</Label>
@@ -83,12 +131,16 @@ export default function EarlyPayoffCalculator() {
                 id="ep-term"
                 type="number"
                 placeholder="e.g. 24"
-                value={originalTerm}
-                onChange={(e) => setOriginalTerm(e.target.value)}
+                value={form.originalTerm}
+                onChange={(e) => setField("originalTerm", e.target.value)}
                 required
-                min="1"
-                step="1"
+                min={1}
+                max={360}
+                step={1}
               />
+              <p className="text-xs text-muted-foreground">
+                Number of months in the original loan agreement
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="ep-extra">Extra Monthly Payment</Label>
@@ -96,12 +148,16 @@ export default function EarlyPayoffCalculator() {
                 id="ep-extra"
                 type="number"
                 placeholder="e.g. 2000"
-                value={extraPayment}
-                onChange={(e) => setExtraPayment(e.target.value)}
+                value={form.extraPayment}
+                onChange={(e) => setField("extraPayment", e.target.value)}
                 required
-                min="0"
-                step="any"
+                min={0}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                Additional amount you plan to pay each month on top of the
+                regular installment
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="ep-fee">Processing Fee (optional)</Label>
@@ -109,18 +165,41 @@ export default function EarlyPayoffCalculator() {
                 id="ep-fee"
                 type="number"
                 placeholder="e.g. 500"
-                value={processingFee}
-                onChange={(e) => setProcessingFee(e.target.value)}
-                min="0"
-                step="any"
+                value={form.processingFee}
+                onChange={(e) => setField("processingFee", e.target.value)}
+                min={0}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                One-time fee included in the total loan cost
+              </p>
             </div>
           </div>
-          <Button type="submit">Calculate</Button>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
         {result && (
-          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div
+            className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+            role="region"
+            aria-label="Early payoff results"
+          >
             <Card>
               <CardHeader>
                 <CardTitle className="text-base">Original Schedule</CardTitle>

--- a/components/tools/early-payoff-calculator.tsx
+++ b/components/tools/early-payoff-calculator.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  calculateEarlyPayoff,
+  type EarlyPayoffResult,
+} from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function EarlyPayoffCalculator() {
+  const [principal, setPrincipal] = useState("");
+  const [monthlyRate, setMonthlyRate] = useState("");
+  const [originalTerm, setOriginalTerm] = useState("");
+  const [extraPayment, setExtraPayment] = useState("");
+  const [processingFee, setProcessingFee] = useState("");
+  const [result, setResult] = useState<EarlyPayoffResult | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const p = parseFloat(principal);
+    const rate = parseFloat(monthlyRate) / 100;
+    const term = parseInt(originalTerm, 10);
+    const extra = parseFloat(extraPayment);
+    const fee = processingFee ? parseFloat(processingFee) : 0;
+
+    if (isNaN(p) || isNaN(rate) || isNaN(term) || isNaN(extra)) return;
+
+    const res = calculateEarlyPayoff(p, rate, term, extra, fee);
+    setResult(res);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Early Payoff Calculator</CardTitle>
+        <CardDescription>
+          See how much time and money you can save by making extra monthly
+          payments on your loan.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="ep-principal">Principal</Label>
+              <Input
+                id="ep-principal"
+                type="number"
+                placeholder="e.g. 100000"
+                value={principal}
+                onChange={(e) => setPrincipal(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ep-rate">Monthly Rate (%)</Label>
+              <Input
+                id="ep-rate"
+                type="number"
+                placeholder="e.g. 1.5"
+                value={monthlyRate}
+                onChange={(e) => setMonthlyRate(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ep-term">Original Term (months)</Label>
+              <Input
+                id="ep-term"
+                type="number"
+                placeholder="e.g. 24"
+                value={originalTerm}
+                onChange={(e) => setOriginalTerm(e.target.value)}
+                required
+                min="1"
+                step="1"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ep-extra">Extra Monthly Payment</Label>
+              <Input
+                id="ep-extra"
+                type="number"
+                placeholder="e.g. 2000"
+                value={extraPayment}
+                onChange={(e) => setExtraPayment(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ep-fee">Processing Fee (optional)</Label>
+              <Input
+                id="ep-fee"
+                type="number"
+                placeholder="e.g. 500"
+                value={processingFee}
+                onChange={(e) => setProcessingFee(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+          </div>
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {result && (
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Original Schedule</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Term</span>
+                  <span className="font-medium">
+                    {result.originalMonths} months
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Total Interest</span>
+                  <span className="font-medium">
+                    {formatCurrency(result.originalTotalInterest)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Total Payment</span>
+                  <span className="font-medium">
+                    {formatCurrency(result.originalTotalPayment)}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">
+                  Accelerated Schedule
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Term</span>
+                  <span className="font-medium">
+                    {result.newMonths} months
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Total Interest</span>
+                  <span className="font-medium">
+                    {formatCurrency(result.newTotalInterest)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Total Payment</span>
+                  <span className="font-medium">
+                    {formatCurrency(result.newTotalPayment)}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">You Save</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Months Saved</span>
+                  <span className="font-medium text-green-600">
+                    {result.monthsSaved} months
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Interest Saved</span>
+                  <span className="font-medium text-green-600">
+                    {formatCurrency(result.interestSaved)}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/emergency-fund-calculator.tsx
+++ b/components/tools/emergency-fund-calculator.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  calculateEmergencyFund,
+  type EmergencyFundResult,
+} from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function EmergencyFundCalculator() {
+  const [monthlyExpenses, setMonthlyExpenses] = useState("");
+  const [targetMonths, setTargetMonths] = useState("6");
+  const [currentSavings, setCurrentSavings] = useState("");
+  const [monthlySavingsCapacity, setMonthlySavingsCapacity] = useState("");
+  const [results, setResults] = useState<EmergencyFundResult | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const expenses = parseFloat(monthlyExpenses);
+    const months = parseInt(targetMonths) || 6;
+    const savings = parseFloat(currentSavings) || 0;
+    const capacity = parseFloat(monthlySavingsCapacity) || 0;
+
+    if (isNaN(expenses) || expenses <= 0) return;
+
+    const result = calculateEmergencyFund(expenses, months, savings, capacity);
+    setResults(result);
+  };
+
+  const progressPercent = results
+    ? Math.min(
+        100,
+        results.targetAmount > 0
+          ? (results.currentSavings / results.targetAmount) * 100
+          : 0
+      )
+    : 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Emergency Fund Calculator</CardTitle>
+        <CardDescription>
+          Calculate how much you need in your emergency fund and how long it will
+          take to build it.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="space-y-2">
+              <Label htmlFor="ef-expenses">Monthly Expenses</Label>
+              <Input
+                id="ef-expenses"
+                type="number"
+                placeholder="e.g. 30000"
+                value={monthlyExpenses}
+                onChange={(e) => setMonthlyExpenses(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ef-months">Target Months of Coverage</Label>
+              <Input
+                id="ef-months"
+                type="number"
+                placeholder="e.g. 6"
+                value={targetMonths}
+                onChange={(e) => setTargetMonths(e.target.value)}
+                min="1"
+                step="1"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ef-current">Current Savings</Label>
+              <Input
+                id="ef-current"
+                type="number"
+                placeholder="e.g. 50000"
+                value={currentSavings}
+                onChange={(e) => setCurrentSavings(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ef-capacity">Monthly Savings Capacity</Label>
+              <Input
+                id="ef-capacity"
+                type="number"
+                placeholder="e.g. 5000"
+                value={monthlySavingsCapacity}
+                onChange={(e) => setMonthlySavingsCapacity(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+          </div>
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {results && (
+          <div className="mt-6 space-y-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Target Amount</p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.targetAmount)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  Current Coverage
+                </p>
+                <p className="text-lg font-semibold">
+                  {results.coverageMonths.toFixed(1)} months
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  Remaining to Save
+                </p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.remaining)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  Months to Reach Goal
+                </p>
+                <p className="text-lg font-semibold">
+                  {results.monthsToGoal > 0
+                    ? `${results.monthsToGoal} months`
+                    : "Goal reached!"}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Progress</span>
+                <span className="font-medium">
+                  {progressPercent.toFixed(1)}%
+                </span>
+              </div>
+              <div className="h-4 w-full overflow-hidden rounded-full bg-secondary">
+                <div
+                  className="h-full rounded-full bg-primary transition-all duration-500"
+                  style={{ width: `${progressPercent}%` }}
+                />
+              </div>
+              <div className="flex justify-between text-xs text-muted-foreground">
+                <span>{formatCurrency(results.currentSavings)}</span>
+                <span>{formatCurrency(results.targetAmount)}</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/in-house-loan-calculator.tsx
+++ b/components/tools/in-house-loan-calculator.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  calculateInHouseLoan,
+  type InHouseLoanResult,
+} from "@/lib/calculators";
+import { formatCurrency, formatPercent } from "@/lib/client";
+
+export default function InHouseLoanCalculator() {
+  const [totalPrice, setTotalPrice] = useState("");
+  const [downPaymentPercent, setDownPaymentPercent] = useState("");
+  const [monthlyRate, setMonthlyRate] = useState("");
+  const [termMonths, setTermMonths] = useState("");
+  const [balloonPayment, setBalloonPayment] = useState("");
+  const [result, setResult] = useState<InHouseLoanResult | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const price = parseFloat(totalPrice);
+    const dp = parseFloat(downPaymentPercent);
+    const rate = parseFloat(monthlyRate) / 100;
+    const term = parseInt(termMonths, 10);
+    const balloon = balloonPayment ? parseFloat(balloonPayment) : 0;
+
+    if (isNaN(price) || isNaN(dp) || isNaN(rate) || isNaN(term)) return;
+
+    const res = calculateInHouseLoan(price, dp, rate, term, balloon);
+    setResult(res);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>In-House Loan Calculator</CardTitle>
+        <CardDescription>
+          Calculate monthly payments for in-house financing with down payment and
+          optional balloon payment.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="ih-price">Total Price</Label>
+              <Input
+                id="ih-price"
+                type="number"
+                placeholder="e.g. 2000000"
+                value={totalPrice}
+                onChange={(e) => setTotalPrice(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ih-dp">Down Payment (%)</Label>
+              <Input
+                id="ih-dp"
+                type="number"
+                placeholder="e.g. 20"
+                value={downPaymentPercent}
+                onChange={(e) => setDownPaymentPercent(e.target.value)}
+                required
+                min="0"
+                max="100"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ih-rate">Monthly Rate (%)</Label>
+              <Input
+                id="ih-rate"
+                type="number"
+                placeholder="e.g. 1.25"
+                value={monthlyRate}
+                onChange={(e) => setMonthlyRate(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ih-term">Term (months)</Label>
+              <Input
+                id="ih-term"
+                type="number"
+                placeholder="e.g. 60"
+                value={termMonths}
+                onChange={(e) => setTermMonths(e.target.value)}
+                required
+                min="1"
+                step="1"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ih-balloon">Balloon Payment (optional)</Label>
+              <Input
+                id="ih-balloon"
+                type="number"
+                placeholder="e.g. 100000"
+                value={balloonPayment}
+                onChange={(e) => setBalloonPayment(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+          </div>
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {result && (
+          <div className="mt-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Loan Breakdown</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div className="space-y-3 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Total Price
+                      </span>
+                      <span className="font-medium">
+                        {formatCurrency(result.totalPrice)}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Down Payment ({formatPercent(parseFloat(downPaymentPercent))})
+                      </span>
+                      <span className="font-medium">
+                        {formatCurrency(result.downPayment)}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Loan Amount
+                      </span>
+                      <span className="font-medium">
+                        {formatCurrency(result.loanAmount)}
+                      </span>
+                    </div>
+                    {result.balloonPayment > 0 && (
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">
+                          Balloon Payment
+                        </span>
+                        <span className="font-medium">
+                          {formatCurrency(result.balloonPayment)}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="space-y-3 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Monthly Payment
+                      </span>
+                      <span className="font-medium text-lg">
+                        {formatCurrency(result.monthlyPayment)}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Total Interest
+                      </span>
+                      <span className="font-medium">
+                        {formatCurrency(result.totalInterest)}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Total Cost
+                      </span>
+                      <span className="font-medium">
+                        {formatCurrency(result.totalPayment)}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/in-house-loan-calculator.tsx
+++ b/components/tools/in-house-loan-calculator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer, useCallback } from "react";
 import {
   Card,
   CardHeader,
@@ -11,32 +11,73 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import {
-  calculateInHouseLoan,
-  type InHouseLoanResult,
-} from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { InHouseLoanResult } from "@/lib/calculators";
 import { formatCurrency, formatPercent } from "@/lib/client";
 
-export default function InHouseLoanCalculator() {
-  const [totalPrice, setTotalPrice] = useState("");
-  const [downPaymentPercent, setDownPaymentPercent] = useState("");
-  const [monthlyRate, setMonthlyRate] = useState("");
-  const [termMonths, setTermMonths] = useState("");
-  const [balloonPayment, setBalloonPayment] = useState("");
-  const [result, setResult] = useState<InHouseLoanResult | null>(null);
+interface FormState {
+  totalPrice: string;
+  downPaymentPercent: string;
+  monthlyRate: string;
+  termMonths: string;
+  balloonPayment: string;
+}
 
-  const handleCalculate = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  totalPrice: "",
+  downPaymentPercent: "",
+  monthlyRate: "",
+  termMonths: "",
+  balloonPayment: "",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function InHouseLoanCalculator() {
+  const [form, formDispatch] = useReducer(formReducer, initialState);
+  const setField = useCallback(
+    (field: keyof FormState, value: string) =>
+      formDispatch({ type: "SET_FIELD", field, value }),
+    []
+  );
+
+  const {
+    data: result,
+    isLoading,
+    error,
+    calculate,
+  } = useToolCalculator<InHouseLoanResult>("in-house-loan");
+
+  const handleCalculate = async (e: React.FormEvent) => {
     e.preventDefault();
-    const price = parseFloat(totalPrice);
-    const dp = parseFloat(downPaymentPercent);
-    const rate = parseFloat(monthlyRate) / 100;
-    const term = parseInt(termMonths, 10);
-    const balloon = balloonPayment ? parseFloat(balloonPayment) : 0;
+    const price = parseFloat(form.totalPrice);
+    const dp = parseFloat(form.downPaymentPercent);
+    const rate = parseFloat(form.monthlyRate) / 100;
+    const term = parseInt(form.termMonths, 10);
+    const balloon = form.balloonPayment ? parseFloat(form.balloonPayment) : 0;
 
     if (isNaN(price) || isNaN(dp) || isNaN(rate) || isNaN(term)) return;
 
-    const res = calculateInHouseLoan(price, dp, rate, term, balloon);
-    setResult(res);
+    await calculate({
+      totalPrice: price,
+      downPaymentPercent: dp,
+      monthlyRate: rate,
+      months: term,
+      balloonPayment: balloon,
+    });
   };
 
   return (
@@ -57,12 +98,15 @@ export default function InHouseLoanCalculator() {
                 id="ih-price"
                 type="number"
                 placeholder="e.g. 2000000"
-                value={totalPrice}
-                onChange={(e) => setTotalPrice(e.target.value)}
+                value={form.totalPrice}
+                onChange={(e) => setField("totalPrice", e.target.value)}
                 required
-                min="0"
-                step="any"
+                min={0}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                Full purchase price of the property or item
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="ih-dp">Down Payment (%)</Label>
@@ -70,13 +114,16 @@ export default function InHouseLoanCalculator() {
                 id="ih-dp"
                 type="number"
                 placeholder="e.g. 20"
-                value={downPaymentPercent}
-                onChange={(e) => setDownPaymentPercent(e.target.value)}
+                value={form.downPaymentPercent}
+                onChange={(e) => setField("downPaymentPercent", e.target.value)}
                 required
-                min="0"
-                max="100"
-                step="any"
+                min={0}
+                max={100}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                Percentage of the total price paid upfront
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="ih-rate">Monthly Rate (%)</Label>
@@ -84,12 +131,16 @@ export default function InHouseLoanCalculator() {
                 id="ih-rate"
                 type="number"
                 placeholder="e.g. 1.25"
-                value={monthlyRate}
-                onChange={(e) => setMonthlyRate(e.target.value)}
+                value={form.monthlyRate}
+                onChange={(e) => setField("monthlyRate", e.target.value)}
                 required
-                min="0"
-                step="any"
+                min={0}
+                max={100}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                Monthly add-on (flat) interest rate charged by the developer
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="ih-term">Term (months)</Label>
@@ -97,12 +148,16 @@ export default function InHouseLoanCalculator() {
                 id="ih-term"
                 type="number"
                 placeholder="e.g. 60"
-                value={termMonths}
-                onChange={(e) => setTermMonths(e.target.value)}
+                value={form.termMonths}
+                onChange={(e) => setField("termMonths", e.target.value)}
                 required
-                min="1"
-                step="1"
+                min={1}
+                max={360}
+                step={1}
               />
+              <p className="text-xs text-muted-foreground">
+                Number of monthly installments
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="ih-balloon">Balloon Payment (optional)</Label>
@@ -110,18 +165,37 @@ export default function InHouseLoanCalculator() {
                 id="ih-balloon"
                 type="number"
                 placeholder="e.g. 100000"
-                value={balloonPayment}
-                onChange={(e) => setBalloonPayment(e.target.value)}
-                min="0"
-                step="any"
+                value={form.balloonPayment}
+                onChange={(e) => setField("balloonPayment", e.target.value)}
+                min={0}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                Optional lump-sum payment due at end of term
+              </p>
             </div>
           </div>
-          <Button type="submit">Calculate</Button>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
         {result && (
-          <div className="mt-6">
+          <div className="mt-6" role="region" aria-label="In-house loan results">
             <Card>
               <CardHeader>
                 <CardTitle className="text-base">Loan Breakdown</CardTitle>
@@ -139,7 +213,7 @@ export default function InHouseLoanCalculator() {
                     </div>
                     <div className="flex justify-between">
                       <span className="text-muted-foreground">
-                        Down Payment ({formatPercent(parseFloat(downPaymentPercent))})
+                        Down Payment ({formatPercent(parseFloat(form.downPaymentPercent))})
                       </span>
                       <span className="font-medium">
                         {formatCurrency(result.downPayment)}

--- a/components/tools/interest-rate-converter.tsx
+++ b/components/tools/interest-rate-converter.tsx
@@ -1,24 +1,49 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { convertInterestRate, type RateConversionResult } from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { RateConversionResult } from "@/lib/calculators";
 import { formatPercent } from "@/lib/client";
 
-export default function InterestRateConverter() {
-  const [flatRate, setFlatRate] = useState("");
-  const [termMonths, setTermMonths] = useState("");
-  const [result, setResult] = useState<RateConversionResult | null>(null);
+interface FormState {
+  flatRate: string;
+  termMonths: string;
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  flatRate: "",
+  termMonths: "",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function InterestRateConverter() {
+  const [form, dispatch] = useReducer(formReducer, initialState);
+  const { data: result, isLoading, error, calculate } = useToolCalculator<RateConversionResult>("rate-converter");
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const rate = parseFloat(flatRate);
-    const months = parseInt(termMonths);
+    const rate = parseFloat(form.flatRate);
+    const months = parseInt(form.termMonths);
     if (isNaN(rate) || isNaN(months) || months <= 0) return;
-    setResult(convertInterestRate(rate / 100, months));
+    await calculate({ flatRateMonthly: rate / 100, months });
   };
 
   return (
@@ -39,30 +64,54 @@ export default function InterestRateConverter() {
                 type="number"
                 step="0.01"
                 min="0"
-                placeholder="e.g. 1.5"
-                value={flatRate}
-                onChange={(e) => setFlatRate(e.target.value)}
+                max="100"
+                placeholder="e.g. 0.99"
+                value={form.flatRate}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "flatRate", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                The monthly add-on rate advertised by the bank (e.g. 0.99% or 1.5%).
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="term-months">Term (Months)</Label>
               <Input
                 id="term-months"
                 type="number"
+                step="1"
                 min="1"
+                max="360"
                 placeholder="e.g. 12"
-                value={termMonths}
-                onChange={(e) => setTermMonths(e.target.value)}
+                value={form.termMonths}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "termMonths", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                Number of monthly installments for the loan.
+              </p>
             </div>
           </div>
-          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+          <Button type="submit" className="w-full sm:w-auto" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {result && (
-          <div className="space-y-4">
+          <div className="space-y-4" aria-label="Conversion results">
             <h4 className="text-sm font-semibold text-muted-foreground">Conversion Results</h4>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
               <div className="rounded-lg border p-3">
@@ -80,10 +129,16 @@ export default function InterestRateConverter() {
               <div className="rounded-lg border border-primary/30 bg-primary/5 p-3">
                 <Label className="text-xs text-muted-foreground">EIR (Monthly)</Label>
                 <p className="text-lg font-bold text-primary">{formatPercent(result.eirMonthly.toFixed(4))}</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Effective Interest Rate per month, accounting for diminishing principal.
+                </p>
               </div>
               <div className="rounded-lg border border-primary/30 bg-primary/5 p-3">
                 <Label className="text-xs text-muted-foreground">EIR (Annual)</Label>
                 <p className="text-lg font-bold text-primary">{formatPercent(result.eirAnnual.toFixed(2))}</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  The true annual cost of the loan, comparable across products.
+                </p>
               </div>
               <div className="rounded-lg border p-3">
                 <Label className="text-xs text-muted-foreground">Factor Rate</Label>

--- a/components/tools/interest-rate-converter.tsx
+++ b/components/tools/interest-rate-converter.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { convertInterestRate, type RateConversionResult } from "@/lib/calculators";
+import { formatPercent } from "@/lib/client";
+
+export default function InterestRateConverter() {
+  const [flatRate, setFlatRate] = useState("");
+  const [termMonths, setTermMonths] = useState("");
+  const [result, setResult] = useState<RateConversionResult | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const rate = parseFloat(flatRate);
+    const months = parseInt(termMonths);
+    if (isNaN(rate) || isNaN(months) || months <= 0) return;
+    setResult(convertInterestRate(rate / 100, months));
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Interest Rate Converter</CardTitle>
+        <CardDescription>
+          Convert flat monthly rates to effective interest rates (EIR) and factor rates.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="flat-rate">Flat Monthly Rate (%)</Label>
+              <Input
+                id="flat-rate"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 1.5"
+                value={flatRate}
+                onChange={(e) => setFlatRate(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="term-months">Term (Months)</Label>
+              <Input
+                id="term-months"
+                type="number"
+                min="1"
+                placeholder="e.g. 12"
+                value={termMonths}
+                onChange={(e) => setTermMonths(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+        </form>
+
+        {result && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-muted-foreground">Conversion Results</h4>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              <div className="rounded-lg border p-3">
+                <Label className="text-xs text-muted-foreground">Flat Rate (Monthly)</Label>
+                <p className="text-lg font-semibold">{formatPercent(result.flatRateMonthly.toFixed(2))}</p>
+              </div>
+              <div className="rounded-lg border p-3">
+                <Label className="text-xs text-muted-foreground">Flat Rate (Annual)</Label>
+                <p className="text-lg font-semibold">{formatPercent(result.flatRateAnnual.toFixed(2))}</p>
+              </div>
+              <div className="rounded-lg border p-3">
+                <Label className="text-xs text-muted-foreground">Total Interest %</Label>
+                <p className="text-lg font-semibold">{formatPercent(result.totalInterestPercent.toFixed(2))}</p>
+              </div>
+              <div className="rounded-lg border border-primary/30 bg-primary/5 p-3">
+                <Label className="text-xs text-muted-foreground">EIR (Monthly)</Label>
+                <p className="text-lg font-bold text-primary">{formatPercent(result.eirMonthly.toFixed(4))}</p>
+              </div>
+              <div className="rounded-lg border border-primary/30 bg-primary/5 p-3">
+                <Label className="text-xs text-muted-foreground">EIR (Annual)</Label>
+                <p className="text-lg font-bold text-primary">{formatPercent(result.eirAnnual.toFixed(2))}</p>
+              </div>
+              <div className="rounded-lg border p-3">
+                <Label className="text-xs text-muted-foreground">Factor Rate</Label>
+                <p className="text-lg font-semibold">{result.factorRate.toFixed(6)}</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/investment-calculator.tsx
+++ b/components/tools/investment-calculator.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  calculateInvestmentReturn,
+  type InvestmentResult,
+} from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function InvestmentCalculator() {
+  const [initialAmount, setInitialAmount] = useState("");
+  const [monthlyContribution, setMonthlyContribution] = useState("");
+  const [years, setYears] = useState("");
+  const [annualReturn, setAnnualReturn] = useState("");
+  const [taxRate, setTaxRate] = useState("20");
+  const [results, setResults] = useState<InvestmentResult | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const initial = parseFloat(initialAmount) || 0;
+    const monthly = parseFloat(monthlyContribution) || 0;
+    const yrs = parseInt(years);
+    const rate = parseFloat(annualReturn);
+    const tax = parseFloat(taxRate) || 20;
+
+    if (isNaN(yrs) || isNaN(rate) || yrs <= 0) return;
+
+    const result = calculateInvestmentReturn(
+      initial,
+      monthly,
+      yrs,
+      rate / 100,
+      tax / 100
+    );
+    setResults(result);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Investment Returns Calculator</CardTitle>
+        <CardDescription>
+          Project investment growth with regular contributions and withholding
+          tax.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+            <div className="space-y-2">
+              <Label htmlFor="inv-initial">Initial Investment</Label>
+              <Input
+                id="inv-initial"
+                type="number"
+                placeholder="e.g. 100000"
+                value={initialAmount}
+                onChange={(e) => setInitialAmount(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="inv-monthly">Monthly Contribution</Label>
+              <Input
+                id="inv-monthly"
+                type="number"
+                placeholder="e.g. 5000"
+                value={monthlyContribution}
+                onChange={(e) => setMonthlyContribution(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="inv-years">Investment Period (years)</Label>
+              <Input
+                id="inv-years"
+                type="number"
+                placeholder="e.g. 10"
+                value={years}
+                onChange={(e) => setYears(e.target.value)}
+                required
+                min="1"
+                max="50"
+                step="1"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="inv-return">Expected Annual Return (%)</Label>
+              <Input
+                id="inv-return"
+                type="number"
+                placeholder="e.g. 8"
+                value={annualReturn}
+                onChange={(e) => setAnnualReturn(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="inv-tax">Withholding Tax (%)</Label>
+              <Input
+                id="inv-tax"
+                type="number"
+                placeholder="e.g. 20"
+                value={taxRate}
+                onChange={(e) => setTaxRate(e.target.value)}
+                min="0"
+                max="100"
+                step="any"
+              />
+            </div>
+          </div>
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {results && (
+          <div className="mt-6 space-y-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Final Amount</p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.finalAmount)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  Total Contributed
+                </p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.totalContributed)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Total Returns</p>
+                <p className="text-lg font-semibold text-green-600">
+                  {formatCurrency(results.totalReturns)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  After-Tax Returns
+                </p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.afterTaxReturns)}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Tax: {formatCurrency(results.withholdingTax)}
+                </p>
+              </div>
+            </div>
+
+            {results.yearlyBreakdown.length > 0 && (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Year</TableHead>
+                      <TableHead className="text-right">Balance</TableHead>
+                      <TableHead className="text-right">Contributed</TableHead>
+                      <TableHead className="text-right">Returns</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {results.yearlyBreakdown.map((row) => (
+                      <TableRow key={row.year}>
+                        <TableCell>{row.year}</TableCell>
+                        <TableCell className="text-right">
+                          {formatCurrency(row.balance)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatCurrency(row.contributed)}
+                        </TableCell>
+                        <TableCell className="text-right text-green-600">
+                          {formatCurrency(row.returns)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/loan-comparison.tsx
+++ b/components/tools/loan-comparison.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer, useCallback } from "react";
 import {
   Card,
   CardHeader,
@@ -20,45 +20,90 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  compareLoanOffers,
-  type LoanComparisonResult,
-} from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { LoanComparisonResult } from "@/lib/calculators";
 import { formatCurrency } from "@/lib/client";
 
 const TERM_OPTIONS = [3, 6, 9, 12, 18, 24, 36];
 
-export default function LoanComparison() {
-  const [loanAmount, setLoanAmount] = useState("");
-  const [bankAName, setBankAName] = useState("");
-  const [bankARate, setBankARate] = useState("");
-  const [bankAFee, setBankAFee] = useState("");
-  const [bankBName, setBankBName] = useState("");
-  const [bankBRate, setBankBRate] = useState("");
-  const [bankBFee, setBankBFee] = useState("");
-  const [results, setResults] = useState<LoanComparisonResult[] | null>(null);
+interface FormState {
+  loanAmount: string;
+  bankAName: string;
+  bankARate: string;
+  bankAFee: string;
+  bankBName: string;
+  bankBRate: string;
+  bankBFee: string;
+}
 
-  const handleCalculate = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  loanAmount: "",
+  bankAName: "",
+  bankARate: "",
+  bankAFee: "",
+  bankBName: "",
+  bankBRate: "",
+  bankBFee: "",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function LoanComparison() {
+  const [form, formDispatch] = useReducer(formReducer, initialState);
+  const setField = useCallback(
+    (field: keyof FormState, value: string) =>
+      formDispatch({ type: "SET_FIELD", field, value }),
+    []
+  );
+
+  const {
+    data: results,
+    isLoading,
+    error,
+    calculate,
+  } = useToolCalculator<LoanComparisonResult[]>("loan-comparison");
+
+  const handleCalculate = async (e: React.FormEvent) => {
     e.preventDefault();
-    const principal = parseFloat(loanAmount);
-    const rateA = parseFloat(bankARate) / 100;
-    const feeA = parseFloat(bankAFee) || 0;
-    const rateB = parseFloat(bankBRate) / 100;
-    const feeB = parseFloat(bankBFee) || 0;
+    const principal = parseFloat(form.loanAmount);
+    const rateA = parseFloat(form.bankARate) / 100;
+    const feeA = parseFloat(form.bankAFee) || 0;
+    const rateB = parseFloat(form.bankBRate) / 100;
+    const feeB = parseFloat(form.bankBFee) || 0;
 
     if (isNaN(principal) || isNaN(rateA) || isNaN(rateB)) return;
 
-    const offerA = { name: bankAName || "Bank A", rate: rateA, processingFee: feeA };
-    const offerB = { name: bankBName || "Bank B", rate: rateB, processingFee: feeB };
-
-    const rows = TERM_OPTIONS.map((months) =>
-      compareLoanOffers(principal, offerA, offerB, months)
-    );
-    setResults(rows);
+    await calculate({
+      principal,
+      offerA: {
+        name: form.bankAName || "Bank A",
+        rate: rateA,
+        processingFee: feeA,
+      },
+      offerB: {
+        name: form.bankBName || "Bank B",
+        rate: rateB,
+        processingFee: feeB,
+      },
+      months: TERM_OPTIONS,
+    });
   };
 
-  const nameA = bankAName || "Bank A";
-  const nameB = bankBName || "Bank B";
+  const nameA = form.bankAName || "Bank A";
+  const nameB = form.bankBName || "Bank B";
 
   return (
     <Card>
@@ -76,12 +121,15 @@ export default function LoanComparison() {
               id="lc-amount"
               type="number"
               placeholder="e.g. 100000"
-              value={loanAmount}
-              onChange={(e) => setLoanAmount(e.target.value)}
+              value={form.loanAmount}
+              onChange={(e) => setField("loanAmount", e.target.value)}
               required
-              min="0"
-              step="any"
+              min={0}
+              step={0.01}
             />
+            <p className="text-xs text-muted-foreground">
+              The total loan principal you want to borrow
+            </p>
           </div>
 
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -93,9 +141,12 @@ export default function LoanComparison() {
                   id="lc-a-name"
                   type="text"
                   placeholder="e.g. BDO"
-                  value={bankAName}
-                  onChange={(e) => setBankAName(e.target.value)}
+                  value={form.bankAName}
+                  onChange={(e) => setField("bankAName", e.target.value)}
                 />
+                <p className="text-xs text-muted-foreground">
+                  Label for the first bank offer
+                </p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="lc-a-rate">Monthly Rate (%)</Label>
@@ -103,12 +154,16 @@ export default function LoanComparison() {
                   id="lc-a-rate"
                   type="number"
                   placeholder="e.g. 1.5"
-                  value={bankARate}
-                  onChange={(e) => setBankARate(e.target.value)}
+                  value={form.bankARate}
+                  onChange={(e) => setField("bankARate", e.target.value)}
                   required
-                  min="0"
-                  step="any"
+                  min={0}
+                  max={100}
+                  step={0.01}
                 />
+                <p className="text-xs text-muted-foreground">
+                  Monthly add-on interest rate offered by this bank
+                </p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="lc-a-fee">Processing Fee</Label>
@@ -116,11 +171,14 @@ export default function LoanComparison() {
                   id="lc-a-fee"
                   type="number"
                   placeholder="e.g. 500"
-                  value={bankAFee}
-                  onChange={(e) => setBankAFee(e.target.value)}
-                  min="0"
-                  step="any"
+                  value={form.bankAFee}
+                  onChange={(e) => setField("bankAFee", e.target.value)}
+                  min={0}
+                  step={0.01}
                 />
+                <p className="text-xs text-muted-foreground">
+                  One-time processing fee charged by this bank
+                </p>
               </div>
             </div>
 
@@ -132,9 +190,12 @@ export default function LoanComparison() {
                   id="lc-b-name"
                   type="text"
                   placeholder="e.g. BPI"
-                  value={bankBName}
-                  onChange={(e) => setBankBName(e.target.value)}
+                  value={form.bankBName}
+                  onChange={(e) => setField("bankBName", e.target.value)}
                 />
+                <p className="text-xs text-muted-foreground">
+                  Label for the second bank offer
+                </p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="lc-b-rate">Monthly Rate (%)</Label>
@@ -142,12 +203,16 @@ export default function LoanComparison() {
                   id="lc-b-rate"
                   type="number"
                   placeholder="e.g. 1.2"
-                  value={bankBRate}
-                  onChange={(e) => setBankBRate(e.target.value)}
+                  value={form.bankBRate}
+                  onChange={(e) => setField("bankBRate", e.target.value)}
                   required
-                  min="0"
-                  step="any"
+                  min={0}
+                  max={100}
+                  step={0.01}
                 />
+                <p className="text-xs text-muted-foreground">
+                  Monthly add-on interest rate offered by this bank
+                </p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="lc-b-fee">Processing Fee</Label>
@@ -155,20 +220,38 @@ export default function LoanComparison() {
                   id="lc-b-fee"
                   type="number"
                   placeholder="e.g. 1000"
-                  value={bankBFee}
-                  onChange={(e) => setBankBFee(e.target.value)}
-                  min="0"
-                  step="any"
+                  value={form.bankBFee}
+                  onChange={(e) => setField("bankBFee", e.target.value)}
+                  min={0}
+                  step={0.01}
                 />
+                <p className="text-xs text-muted-foreground">
+                  One-time processing fee charged by this bank
+                </p>
               </div>
             </div>
           </div>
 
-          <Button type="submit">Calculate</Button>
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
         {results && (
-          <div className="mt-6">
+          <div className="mt-6" role="region" aria-label="Loan comparison results">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/components/tools/loan-comparison.tsx
+++ b/components/tools/loan-comparison.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  compareLoanOffers,
+  type LoanComparisonResult,
+} from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+const TERM_OPTIONS = [3, 6, 9, 12, 18, 24, 36];
+
+export default function LoanComparison() {
+  const [loanAmount, setLoanAmount] = useState("");
+  const [bankAName, setBankAName] = useState("");
+  const [bankARate, setBankARate] = useState("");
+  const [bankAFee, setBankAFee] = useState("");
+  const [bankBName, setBankBName] = useState("");
+  const [bankBRate, setBankBRate] = useState("");
+  const [bankBFee, setBankBFee] = useState("");
+  const [results, setResults] = useState<LoanComparisonResult[] | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const principal = parseFloat(loanAmount);
+    const rateA = parseFloat(bankARate) / 100;
+    const feeA = parseFloat(bankAFee) || 0;
+    const rateB = parseFloat(bankBRate) / 100;
+    const feeB = parseFloat(bankBFee) || 0;
+
+    if (isNaN(principal) || isNaN(rateA) || isNaN(rateB)) return;
+
+    const offerA = { name: bankAName || "Bank A", rate: rateA, processingFee: feeA };
+    const offerB = { name: bankBName || "Bank B", rate: rateB, processingFee: feeB };
+
+    const rows = TERM_OPTIONS.map((months) =>
+      compareLoanOffers(principal, offerA, offerB, months)
+    );
+    setResults(rows);
+  };
+
+  const nameA = bankAName || "Bank A";
+  const nameB = bankBName || "Bank B";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Loan Comparison</CardTitle>
+        <CardDescription>
+          Compare two bank loan offers side by side across different terms.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="lc-amount">Loan Amount</Label>
+            <Input
+              id="lc-amount"
+              type="number"
+              placeholder="e.g. 100000"
+              value={loanAmount}
+              onChange={(e) => setLoanAmount(e.target.value)}
+              required
+              min="0"
+              step="any"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-3 rounded-lg border p-4">
+              <h4 className="font-medium">Bank A</h4>
+              <div className="space-y-2">
+                <Label htmlFor="lc-a-name">Name</Label>
+                <Input
+                  id="lc-a-name"
+                  type="text"
+                  placeholder="e.g. BDO"
+                  value={bankAName}
+                  onChange={(e) => setBankAName(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="lc-a-rate">Monthly Rate (%)</Label>
+                <Input
+                  id="lc-a-rate"
+                  type="number"
+                  placeholder="e.g. 1.5"
+                  value={bankARate}
+                  onChange={(e) => setBankARate(e.target.value)}
+                  required
+                  min="0"
+                  step="any"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="lc-a-fee">Processing Fee</Label>
+                <Input
+                  id="lc-a-fee"
+                  type="number"
+                  placeholder="e.g. 500"
+                  value={bankAFee}
+                  onChange={(e) => setBankAFee(e.target.value)}
+                  min="0"
+                  step="any"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-3 rounded-lg border p-4">
+              <h4 className="font-medium">Bank B</h4>
+              <div className="space-y-2">
+                <Label htmlFor="lc-b-name">Name</Label>
+                <Input
+                  id="lc-b-name"
+                  type="text"
+                  placeholder="e.g. BPI"
+                  value={bankBName}
+                  onChange={(e) => setBankBName(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="lc-b-rate">Monthly Rate (%)</Label>
+                <Input
+                  id="lc-b-rate"
+                  type="number"
+                  placeholder="e.g. 1.2"
+                  value={bankBRate}
+                  onChange={(e) => setBankBRate(e.target.value)}
+                  required
+                  min="0"
+                  step="any"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="lc-b-fee">Processing Fee</Label>
+                <Input
+                  id="lc-b-fee"
+                  type="number"
+                  placeholder="e.g. 1000"
+                  value={bankBFee}
+                  onChange={(e) => setBankBFee(e.target.value)}
+                  min="0"
+                  step="any"
+                />
+              </div>
+            </div>
+          </div>
+
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {results && (
+          <div className="mt-6">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Months</TableHead>
+                  <TableHead>{nameA} Monthly</TableHead>
+                  <TableHead>{nameA} Total</TableHead>
+                  <TableHead>{nameB} Monthly</TableHead>
+                  <TableHead>{nameB} Total</TableHead>
+                  <TableHead>Savings</TableHead>
+                  <TableHead>Winner</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {results.map((row) => (
+                  <TableRow key={row.months}>
+                    <TableCell>{row.months}</TableCell>
+                    <TableCell>
+                      {formatCurrency(row.offerA.monthlyPayment)}
+                    </TableCell>
+                    <TableCell>
+                      {formatCurrency(row.offerA.totalPayment)}
+                    </TableCell>
+                    <TableCell>
+                      {formatCurrency(row.offerB.monthlyPayment)}
+                    </TableCell>
+                    <TableCell>
+                      {formatCurrency(row.offerB.totalPayment)}
+                    </TableCell>
+                    <TableCell>{formatCurrency(row.savings)}</TableCell>
+                    <TableCell>
+                      {row.winner === "tie" ? (
+                        <Badge variant="secondary">Tie</Badge>
+                      ) : (
+                        <Badge>
+                          {row.winner === "A" ? nameA : nameB}
+                        </Badge>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/pagibig-loan-calculator.tsx
+++ b/components/tools/pagibig-loan-calculator.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  calculatePagIBIGLoan,
+  type PagIBIGLoanResult,
+} from "@/lib/calculators";
+import { formatCurrency, formatPercent } from "@/lib/client";
+
+export default function PagIBIGLoanCalculator() {
+  const [loanAmount, setLoanAmount] = useState("");
+  const [termYears, setTermYears] = useState("30");
+  const [result, setResult] = useState<PagIBIGLoanResult | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const amount = parseFloat(loanAmount);
+    const years = parseInt(termYears, 10);
+
+    if (isNaN(amount) || isNaN(years)) return;
+
+    const res = calculatePagIBIGLoan(amount, years);
+    setResult(res);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Pag-IBIG Loan Calculator</CardTitle>
+        <CardDescription>
+          Estimate your Pag-IBIG housing loan monthly amortization, total
+          payment, and insurance costs.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="pag-amount">Loan Amount</Label>
+              <Input
+                id="pag-amount"
+                type="number"
+                placeholder="e.g. 1000000"
+                value={loanAmount}
+                onChange={(e) => setLoanAmount(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="pag-term">Term (years)</Label>
+              <Input
+                id="pag-term"
+                type="number"
+                placeholder="30"
+                value={termYears}
+                onChange={(e) => setTermYears(e.target.value)}
+                required
+                min="1"
+                max="30"
+                step="1"
+              />
+            </div>
+          </div>
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {result && (
+          <div className="mt-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">
+                  Pag-IBIG Loan Summary
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div className="space-y-3 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Loan Amount
+                      </span>
+                      <span className="font-medium">
+                        {formatCurrency(result.loanAmount)}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Term
+                      </span>
+                      <span className="font-medium">
+                        {result.term / 12} years ({result.term} months)
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Interest Rate
+                      </span>
+                      <span className="font-medium">
+                        {formatPercent(result.annualRate * 100)} per year
+                      </span>
+                    </div>
+                    <div className="flex justify-between border-t pt-3">
+                      <span className="text-muted-foreground">
+                        Monthly Amortization
+                      </span>
+                      <span className="font-medium text-lg">
+                        {formatCurrency(result.monthlyAmortization)}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="space-y-3 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Total Payment
+                      </span>
+                      <span className="font-medium">
+                        {formatCurrency(result.totalPayment)}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Total Interest
+                      </span>
+                      <span className="font-medium">
+                        {formatCurrency(result.totalInterest)}
+                      </span>
+                    </div>
+                    <div className="flex justify-between border-t pt-3">
+                      <span className="text-muted-foreground">
+                        MRI (annual)
+                      </span>
+                      <span className="font-medium">
+                        {formatCurrency(result.mri)}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        Fire Insurance (annual)
+                      </span>
+                      <span className="font-medium">
+                        {formatCurrency(result.fireInsurance)}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/pagibig-loan-calculator.tsx
+++ b/components/tools/pagibig-loan-calculator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer, useCallback } from "react";
 import {
   Card,
   CardHeader,
@@ -11,26 +11,61 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import {
-  calculatePagIBIGLoan,
-  type PagIBIGLoanResult,
-} from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { PagIBIGLoanResult } from "@/lib/calculators";
 import { formatCurrency, formatPercent } from "@/lib/client";
 
-export default function PagIBIGLoanCalculator() {
-  const [loanAmount, setLoanAmount] = useState("");
-  const [termYears, setTermYears] = useState("30");
-  const [result, setResult] = useState<PagIBIGLoanResult | null>(null);
+interface FormState {
+  loanAmount: string;
+  termYears: string;
+}
 
-  const handleCalculate = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  loanAmount: "",
+  termYears: "30",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function PagIBIGLoanCalculator() {
+  const [form, formDispatch] = useReducer(formReducer, initialState);
+  const setField = useCallback(
+    (field: keyof FormState, value: string) =>
+      formDispatch({ type: "SET_FIELD", field, value }),
+    []
+  );
+
+  const {
+    data: result,
+    isLoading,
+    error,
+    calculate,
+  } = useToolCalculator<PagIBIGLoanResult>("pagibig-loan");
+
+  const handleCalculate = async (e: React.FormEvent) => {
     e.preventDefault();
-    const amount = parseFloat(loanAmount);
-    const years = parseInt(termYears, 10);
+    const amount = parseFloat(form.loanAmount);
+    const years = parseInt(form.termYears, 10);
 
     if (isNaN(amount) || isNaN(years)) return;
 
-    const res = calculatePagIBIGLoan(amount, years);
-    setResult(res);
+    await calculate({
+      loanAmount: amount,
+      termYears: years,
+    });
   };
 
   return (
@@ -51,12 +86,15 @@ export default function PagIBIGLoanCalculator() {
                 id="pag-amount"
                 type="number"
                 placeholder="e.g. 1000000"
-                value={loanAmount}
-                onChange={(e) => setLoanAmount(e.target.value)}
+                value={form.loanAmount}
+                onChange={(e) => setField("loanAmount", e.target.value)}
                 required
-                min="0"
-                step="any"
+                min={0}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                Total Pag-IBIG housing loan amount you wish to borrow
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="pag-term">Term (years)</Label>
@@ -64,20 +102,39 @@ export default function PagIBIGLoanCalculator() {
                 id="pag-term"
                 type="number"
                 placeholder="30"
-                value={termYears}
-                onChange={(e) => setTermYears(e.target.value)}
+                value={form.termYears}
+                onChange={(e) => setField("termYears", e.target.value)}
                 required
-                min="1"
-                max="30"
-                step="1"
+                min={1}
+                max={30}
+                step={1}
               />
+              <p className="text-xs text-muted-foreground">
+                Loan repayment period in years (max 30 years)
+              </p>
             </div>
           </div>
-          <Button type="submit">Calculate</Button>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
         {result && (
-          <div className="mt-6">
+          <div className="mt-6" role="region" aria-label="Pag-IBIG loan results">
             <Card>
               <CardHeader>
                 <CardTitle className="text-base">
@@ -145,6 +202,9 @@ export default function PagIBIGLoanCalculator() {
                         {formatCurrency(result.mri)}
                       </span>
                     </div>
+                    <p className="text-xs text-muted-foreground">
+                      Mortgage Redemption Insurance — protects the lender if borrower passes away
+                    </p>
                     <div className="flex justify-between">
                       <span className="text-muted-foreground">
                         Fire Insurance (annual)
@@ -153,6 +213,9 @@ export default function PagIBIGLoanCalculator() {
                         {formatCurrency(result.fireInsurance)}
                       </span>
                     </div>
+                    <p className="text-xs text-muted-foreground">
+                      Required annual coverage for the property
+                    </p>
                   </div>
                 </div>
               </CardContent>

--- a/components/tools/remittance-calculator.tsx
+++ b/components/tools/remittance-calculator.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  calculateRemittance,
+  type RemittanceResult,
+} from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function RemittanceCalculator() {
+  const [sendAmount, setSendAmount] = useState("");
+  const [exchangeRate, setExchangeRate] = useState("");
+  const [serviceFee, setServiceFee] = useState("");
+  const [sendCurrency, setSendCurrency] = useState("USD");
+  const [receiveCurrency, setReceiveCurrency] = useState("PHP");
+  const [results, setResults] = useState<RemittanceResult | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const amount = parseFloat(sendAmount);
+    const rate = parseFloat(exchangeRate);
+    const fee = parseFloat(serviceFee) || 0;
+
+    if (isNaN(amount) || isNaN(rate) || amount <= 0 || rate <= 0) return;
+
+    const result = calculateRemittance(
+      amount,
+      rate,
+      fee,
+      sendCurrency,
+      receiveCurrency
+    );
+    setResults(result);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Remittance Calculator</CardTitle>
+        <CardDescription>
+          Calculate how much your recipient will receive after exchange rates and
+          service fees.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="rem-amount">Send Amount</Label>
+              <Input
+                id="rem-amount"
+                type="number"
+                placeholder="e.g. 500"
+                value={sendAmount}
+                onChange={(e) => setSendAmount(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="rem-rate">
+                Exchange Rate ({receiveCurrency} per {sendCurrency})
+              </Label>
+              <Input
+                id="rem-rate"
+                type="number"
+                placeholder="e.g. 56.50"
+                value={exchangeRate}
+                onChange={(e) => setExchangeRate(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="rem-fee">Service Fee ({sendCurrency})</Label>
+              <Input
+                id="rem-fee"
+                type="number"
+                placeholder="e.g. 5"
+                value={serviceFee}
+                onChange={(e) => setServiceFee(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="rem-send-currency">Send Currency</Label>
+              <Input
+                id="rem-send-currency"
+                type="text"
+                placeholder="e.g. USD"
+                value={sendCurrency}
+                onChange={(e) => setSendCurrency(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="rem-receive-currency">Receive Currency</Label>
+              <Input
+                id="rem-receive-currency"
+                type="text"
+                placeholder="e.g. PHP"
+                value={receiveCurrency}
+                onChange={(e) => setReceiveCurrency(e.target.value)}
+              />
+            </div>
+          </div>
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {results && (
+          <div className="mt-6 space-y-4">
+            <div className="rounded-lg border bg-primary/5 p-6 text-center">
+              <p className="text-sm text-muted-foreground">
+                Recipient Receives
+              </p>
+              <p className="text-3xl font-bold text-primary">
+                {formatCurrency(results.receiveAmount)}{" "}
+                <span className="text-lg font-medium">
+                  {results.receiveCurrency}
+                </span>
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Send Amount</p>
+                <p className="text-lg font-semibold">
+                  {results.sendAmount.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}{" "}
+                  {results.sendCurrency}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Service Fee</p>
+                <p className="text-lg font-semibold">
+                  {results.fee.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}{" "}
+                  {results.sendCurrency}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Total Cost</p>
+                <p className="text-lg font-semibold">
+                  {results.totalCost.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}{" "}
+                  {results.sendCurrency}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Effective Rate</p>
+                <p className="text-lg font-semibold">
+                  {results.effectiveRate.toFixed(4)}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/retirement-calculator.tsx
+++ b/components/tools/retirement-calculator.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  calculateRetirement,
+  type RetirementResult,
+} from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function RetirementCalculator() {
+  const [currentAge, setCurrentAge] = useState("");
+  const [retirementAge, setRetirementAge] = useState("");
+  const [currentSavings, setCurrentSavings] = useState("");
+  const [monthlySavings, setMonthlySavings] = useState("");
+  const [expectedReturn, setExpectedReturn] = useState("");
+  const [monthlyExpenses, setMonthlyExpenses] = useState("");
+  const [retirementDuration, setRetirementDuration] = useState("25");
+  const [results, setResults] = useState<RetirementResult | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const age = parseInt(currentAge);
+    const retAge = parseInt(retirementAge);
+    const savings = parseFloat(currentSavings) || 0;
+    const monthly = parseFloat(monthlySavings) || 0;
+    const returnRate = parseFloat(expectedReturn);
+    const expenses = parseFloat(monthlyExpenses);
+    const duration = parseInt(retirementDuration) || 25;
+
+    if (
+      isNaN(age) ||
+      isNaN(retAge) ||
+      isNaN(returnRate) ||
+      isNaN(expenses) ||
+      retAge <= age
+    )
+      return;
+
+    const result = calculateRetirement(
+      age,
+      retAge,
+      savings,
+      monthly,
+      returnRate / 100,
+      expenses,
+      duration
+    );
+    setResults(result);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Retirement Calculator</CardTitle>
+        <CardDescription>
+          Project whether your savings will be enough to cover retirement
+          expenses.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+            <div className="space-y-2">
+              <Label htmlFor="ret-age">Current Age</Label>
+              <Input
+                id="ret-age"
+                type="number"
+                placeholder="e.g. 30"
+                value={currentAge}
+                onChange={(e) => setCurrentAge(e.target.value)}
+                required
+                min="18"
+                max="100"
+                step="1"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ret-retire-age">Retirement Age</Label>
+              <Input
+                id="ret-retire-age"
+                type="number"
+                placeholder="e.g. 60"
+                value={retirementAge}
+                onChange={(e) => setRetirementAge(e.target.value)}
+                required
+                min="18"
+                max="100"
+                step="1"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ret-current">Current Savings</Label>
+              <Input
+                id="ret-current"
+                type="number"
+                placeholder="e.g. 500000"
+                value={currentSavings}
+                onChange={(e) => setCurrentSavings(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ret-monthly">Monthly Savings</Label>
+              <Input
+                id="ret-monthly"
+                type="number"
+                placeholder="e.g. 10000"
+                value={monthlySavings}
+                onChange={(e) => setMonthlySavings(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ret-return">Expected Annual Return (%)</Label>
+              <Input
+                id="ret-return"
+                type="number"
+                placeholder="e.g. 8"
+                value={expectedReturn}
+                onChange={(e) => setExpectedReturn(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ret-expenses">Monthly Expenses in Retirement</Label>
+              <Input
+                id="ret-expenses"
+                type="number"
+                placeholder="e.g. 30000"
+                value={monthlyExpenses}
+                onChange={(e) => setMonthlyExpenses(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ret-duration">Retirement Duration (years)</Label>
+              <Input
+                id="ret-duration"
+                type="number"
+                placeholder="e.g. 25"
+                value={retirementDuration}
+                onChange={(e) => setRetirementDuration(e.target.value)}
+                min="1"
+                step="1"
+              />
+            </div>
+          </div>
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {results && (
+          <div className="mt-6 space-y-4">
+            <div className="flex items-center gap-3">
+              <p className="text-sm font-medium">Status:</p>
+              {results.onTrack ? (
+                <Badge className="bg-green-600 hover:bg-green-600">
+                  On Track
+                </Badge>
+              ) : (
+                <Badge variant="destructive">Off Track</Badge>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Projected Fund</p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.projectedFund)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Target Fund</p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.targetFund)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Gap Amount</p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.gap)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  Additional Monthly Needed
+                </p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.additionalMonthlyNeeded)}
+                </p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Years to Retirement</p>
+                <p className="text-lg font-semibold">
+                  {results.yearsToRetirement}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  Monthly Needed in Retirement
+                </p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.monthlyNeeded)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">Retirement Age</p>
+                <p className="text-lg font-semibold">{results.retirementAge}</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/salary-calculator.tsx
+++ b/components/tools/salary-calculator.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { calculateSalary, type SalaryBreakdown } from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function SalaryCalculator() {
+  const [grossSalary, setGrossSalary] = useState("");
+  const [result, setResult] = useState<SalaryBreakdown | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const salary = parseFloat(grossSalary);
+    if (isNaN(salary) || salary <= 0) return;
+    setResult(calculateSalary(salary));
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Salary Calculator (Philippines)</CardTitle>
+        <CardDescription>
+          Compute your net take-home pay after SSS, PhilHealth, Pag-IBIG, and withholding tax.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="max-w-sm space-y-2">
+            <Label htmlFor="gross-salary">Gross Monthly Salary</Label>
+            <Input
+              id="gross-salary"
+              type="number"
+              step="0.01"
+              min="0"
+              placeholder="e.g. 35000"
+              value={grossSalary}
+              onChange={(e) => setGrossSalary(e.target.value)}
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+        </form>
+
+        {result && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-muted-foreground">Salary Breakdown</h4>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Item</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Gross Monthly Salary</TableCell>
+                  <TableCell className="text-right font-medium">{formatCurrency(result.grossMonthly)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell className="pl-6 text-muted-foreground">SSS Contribution</TableCell>
+                  <TableCell className="text-right text-orange-600 dark:text-orange-400">
+                    -{formatCurrency(result.sss)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell className="pl-6 text-muted-foreground">PhilHealth Contribution</TableCell>
+                  <TableCell className="text-right text-orange-600 dark:text-orange-400">
+                    -{formatCurrency(result.philHealth)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell className="pl-6 text-muted-foreground">Pag-IBIG Contribution</TableCell>
+                  <TableCell className="text-right text-orange-600 dark:text-orange-400">
+                    -{formatCurrency(result.pagIbig)}
+                  </TableCell>
+                </TableRow>
+                <TableRow className="border-t-2">
+                  <TableCell className="font-medium">Total Contributions</TableCell>
+                  <TableCell className="text-right font-medium text-orange-600 dark:text-orange-400">
+                    -{formatCurrency(result.totalContributions)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Taxable Income</TableCell>
+                  <TableCell className="text-right font-medium">{formatCurrency(result.taxableIncome)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Withholding Tax</TableCell>
+                  <TableCell className="text-right font-medium text-red-600 dark:text-red-400">
+                    -{formatCurrency(result.withholdingTax)}
+                  </TableCell>
+                </TableRow>
+                <TableRow className="border-t-2 bg-primary/5">
+                  <TableCell className="font-bold text-primary">Net Take-Home Pay</TableCell>
+                  <TableCell className="text-right text-xl font-bold text-primary">
+                    {formatCurrency(result.netTakeHome)}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/salary-calculator.tsx
+++ b/components/tools/salary-calculator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -13,18 +13,42 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { calculateSalary, type SalaryBreakdown } from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { SalaryBreakdown } from "@/lib/calculators";
 import { formatCurrency } from "@/lib/client";
 
-export default function SalaryCalculator() {
-  const [grossSalary, setGrossSalary] = useState("");
-  const [result, setResult] = useState<SalaryBreakdown | null>(null);
+interface FormState {
+  grossSalary: string;
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  grossSalary: "",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function SalaryCalculator() {
+  const [form, dispatch] = useReducer(formReducer, initialState);
+  const { data: result, isLoading, error, calculate } = useToolCalculator<SalaryBreakdown>("salary");
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const salary = parseFloat(grossSalary);
+    const salary = parseFloat(form.grossSalary);
     if (isNaN(salary) || salary <= 0) return;
-    setResult(calculateSalary(salary));
+    await calculate({ grossMonthly: salary });
   };
 
   return (
@@ -45,16 +69,34 @@ export default function SalaryCalculator() {
               step="0.01"
               min="0"
               placeholder="e.g. 35000"
-              value={grossSalary}
-              onChange={(e) => setGrossSalary(e.target.value)}
+              value={form.grossSalary}
+              onChange={(e) => dispatch({ type: "SET_FIELD", field: "grossSalary", value: e.target.value })}
               required
             />
+            <p className="text-xs text-muted-foreground">
+              Based on 2024 PH contribution tables and TRAIN law tax brackets.
+            </p>
           </div>
-          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+          <Button type="submit" className="w-full sm:w-auto" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {result && (
-          <div className="space-y-4">
+          <div className="space-y-4" aria-label="Salary breakdown results">
             <h4 className="text-sm font-semibold text-muted-foreground">Salary Breakdown</h4>
             <Table>
               <TableHeader>

--- a/components/tools/savings-goal-calculator.tsx
+++ b/components/tools/savings-goal-calculator.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  calculateSavingsGoal,
+  type SavingsGoalResult,
+} from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function SavingsGoalCalculator() {
+  const [targetAmount, setTargetAmount] = useState("");
+  const [months, setMonths] = useState("");
+  const [annualRate, setAnnualRate] = useState("0");
+  const [results, setResults] = useState<SavingsGoalResult | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const target = parseFloat(targetAmount);
+    const m = parseInt(months);
+    const rate = parseFloat(annualRate) || 0;
+
+    if (isNaN(target) || isNaN(m) || target <= 0 || m <= 0) return;
+
+    const result = calculateSavingsGoal(target, m, rate / 100);
+    setResults(result);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Savings Goal Calculator</CardTitle>
+        <CardDescription>
+          Find out how much you need to save each month to reach your financial
+          goal.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="sg-target">Target Amount</Label>
+              <Input
+                id="sg-target"
+                type="number"
+                placeholder="e.g. 100000"
+                value={targetAmount}
+                onChange={(e) => setTargetAmount(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="sg-months">Months to Reach Goal</Label>
+              <Input
+                id="sg-months"
+                type="number"
+                placeholder="e.g. 24"
+                value={months}
+                onChange={(e) => setMonths(e.target.value)}
+                required
+                min="1"
+                step="1"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="sg-rate">Annual Interest Rate (%)</Label>
+              <Input
+                id="sg-rate"
+                type="number"
+                placeholder="e.g. 4"
+                value={annualRate}
+                onChange={(e) => setAnnualRate(e.target.value)}
+                min="0"
+                step="any"
+              />
+            </div>
+          </div>
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {results && (
+          <div className="mt-6 space-y-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  Monthly Deposit Needed
+                </p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.monthlyDeposit)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  Total Deposited
+                </p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.totalDeposited)}
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  Interest Earned
+                </p>
+                <p className="text-lg font-semibold">
+                  {formatCurrency(results.totalInterestEarned)}
+                </p>
+              </div>
+            </div>
+
+            {results.milestones.length > 0 && (
+              <div>
+                <p className="mb-2 text-sm font-medium">Milestones</p>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Milestone</TableHead>
+                      <TableHead>Month</TableHead>
+                      <TableHead>Amount</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {results.milestones.map((m) => (
+                      <TableRow key={m.percent}>
+                        <TableCell>{m.percent}%</TableCell>
+                        <TableCell>Month {m.month}</TableCell>
+                        <TableCell>{formatCurrency(m.amount)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/savings-goal-calculator.tsx
+++ b/components/tools/savings-goal-calculator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer, useCallback } from "react";
 import {
   Card,
   CardHeader,
@@ -19,29 +19,63 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  calculateSavingsGoal,
-  type SavingsGoalResult,
-} from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { SavingsGoalResult } from "@/lib/calculators";
 import { formatCurrency } from "@/lib/client";
 
+interface FormState {
+  targetAmount: string;
+  months: string;
+  annualRate: string;
+}
+
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  targetAmount: "",
+  months: "",
+  annualRate: "0",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
 export default function SavingsGoalCalculator() {
-  const [targetAmount, setTargetAmount] = useState("");
-  const [months, setMonths] = useState("");
-  const [annualRate, setAnnualRate] = useState("0");
-  const [results, setResults] = useState<SavingsGoalResult | null>(null);
+  const [form, dispatch] = useReducer(formReducer, initialState);
+  const {
+    data: results,
+    isLoading,
+    error,
+    calculate,
+  } = useToolCalculator<SavingsGoalResult>("savings-goal");
 
-  const handleCalculate = (e: React.FormEvent) => {
-    e.preventDefault();
-    const target = parseFloat(targetAmount);
-    const m = parseInt(months);
-    const rate = parseFloat(annualRate) || 0;
+  const handleCalculate = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const target = parseFloat(form.targetAmount);
+      const m = parseInt(form.months);
+      const rate = parseFloat(form.annualRate) || 0;
 
-    if (isNaN(target) || isNaN(m) || target <= 0 || m <= 0) return;
+      if (isNaN(target) || isNaN(m) || target <= 0 || m <= 0) return;
 
-    const result = calculateSavingsGoal(target, m, rate / 100);
-    setResults(result);
-  };
+      await calculate({
+        targetAmount: target,
+        months: m,
+        annualRate: rate / 100,
+      });
+    },
+    [form, calculate]
+  );
 
   return (
     <Card>
@@ -61,12 +95,21 @@ export default function SavingsGoalCalculator() {
                 id="sg-target"
                 type="number"
                 placeholder="e.g. 100000"
-                value={targetAmount}
-                onChange={(e) => setTargetAmount(e.target.value)}
+                value={form.targetAmount}
+                onChange={(e) =>
+                  dispatch({
+                    type: "SET_FIELD",
+                    field: "targetAmount",
+                    value: e.target.value,
+                  })
+                }
                 required
-                min="0"
-                step="any"
+                min="0.01"
+                step="0.01"
               />
+              <p className="text-xs text-muted-foreground">
+                Your financial goal amount
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="sg-months">Months to Reach Goal</Label>
@@ -74,12 +117,22 @@ export default function SavingsGoalCalculator() {
                 id="sg-months"
                 type="number"
                 placeholder="e.g. 24"
-                value={months}
-                onChange={(e) => setMonths(e.target.value)}
+                value={form.months}
+                onChange={(e) =>
+                  dispatch({
+                    type: "SET_FIELD",
+                    field: "months",
+                    value: e.target.value,
+                  })
+                }
                 required
                 min="1"
+                max="600"
                 step="1"
               />
+              <p className="text-xs text-muted-foreground">
+                Number of months to reach your goal
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="sg-rate">Annual Interest Rate (%)</Label>
@@ -87,18 +140,45 @@ export default function SavingsGoalCalculator() {
                 id="sg-rate"
                 type="number"
                 placeholder="e.g. 4"
-                value={annualRate}
-                onChange={(e) => setAnnualRate(e.target.value)}
+                value={form.annualRate}
+                onChange={(e) =>
+                  dispatch({
+                    type: "SET_FIELD",
+                    field: "annualRate",
+                    value: e.target.value,
+                  })
+                }
                 min="0"
-                step="any"
+                max="100"
+                step="0.01"
               />
+              <p className="text-xs text-muted-foreground">
+                Expected annual return on savings (e.g., high-yield savings or
+                money market)
+              </p>
             </div>
           </div>
-          <Button type="submit">Calculate</Button>
+
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
+        {error && (
+          <Alert variant="destructive" className="mt-4">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {results && (
-          <div className="mt-6 space-y-4">
+          <div className="mt-6 space-y-4" aria-label="Savings goal results">
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
               <div className="rounded-md border p-3">
                 <p className="text-sm text-muted-foreground">

--- a/components/tools/sss-loan-calculator.tsx
+++ b/components/tools/sss-loan-calculator.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { calculateSSSLoan, type SSSLoanResult } from "@/lib/calculators";
+import { formatCurrency } from "@/lib/client";
+
+export default function SSSLoanCalculator() {
+  const [loanAmount, setLoanAmount] = useState("");
+  const [annualRate, setAnnualRate] = useState("10");
+  const [termMonths, setTermMonths] = useState("24");
+  const [result, setResult] = useState<SSSLoanResult | null>(null);
+
+  const handleCalculate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const amount = parseFloat(loanAmount);
+    const rate = parseFloat(annualRate) / 100;
+    const term = parseInt(termMonths, 10);
+
+    if (isNaN(amount) || isNaN(rate) || isNaN(term)) return;
+
+    const res = calculateSSSLoan(amount, rate, term);
+    setResult(res);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>SSS Loan Calculator</CardTitle>
+        <CardDescription>
+          Compute your SSS salary loan amortization, total payment, and total
+          interest.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleCalculate} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="sss-amount">Loan Amount</Label>
+              <Input
+                id="sss-amount"
+                type="number"
+                placeholder="e.g. 20000"
+                value={loanAmount}
+                onChange={(e) => setLoanAmount(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="sss-rate">Annual Rate (%)</Label>
+              <Input
+                id="sss-rate"
+                type="number"
+                placeholder="10"
+                value={annualRate}
+                onChange={(e) => setAnnualRate(e.target.value)}
+                required
+                min="0"
+                step="any"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="sss-term">Term (months)</Label>
+              <Input
+                id="sss-term"
+                type="number"
+                placeholder="24"
+                value={termMonths}
+                onChange={(e) => setTermMonths(e.target.value)}
+                required
+                min="1"
+                step="1"
+              />
+            </div>
+          </div>
+          <Button type="submit">Calculate</Button>
+        </form>
+
+        {result && (
+          <div className="mt-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">SSS Loan Summary</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3 text-sm">
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Loan Amount</span>
+                    <span className="font-medium">
+                      {formatCurrency(result.loanAmount)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">
+                      Term
+                    </span>
+                    <span className="font-medium">{result.term} months</span>
+                  </div>
+                  <div className="flex justify-between border-t pt-3">
+                    <span className="text-muted-foreground">
+                      Monthly Amortization
+                    </span>
+                    <span className="font-medium text-lg">
+                      {formatCurrency(result.monthlyAmortization)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">
+                      Total Payment
+                    </span>
+                    <span className="font-medium">
+                      {formatCurrency(result.totalPayment)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">
+                      Total Interest
+                    </span>
+                    <span className="font-medium">
+                      {formatCurrency(result.totalInterest)}
+                    </span>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tools/sss-loan-calculator.tsx
+++ b/components/tools/sss-loan-calculator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer, useCallback } from "react";
 import {
   Card,
   CardHeader,
@@ -11,25 +11,65 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { calculateSSSLoan, type SSSLoanResult } from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { SSSLoanResult } from "@/lib/calculators";
 import { formatCurrency } from "@/lib/client";
 
-export default function SSSLoanCalculator() {
-  const [loanAmount, setLoanAmount] = useState("");
-  const [annualRate, setAnnualRate] = useState("10");
-  const [termMonths, setTermMonths] = useState("24");
-  const [result, setResult] = useState<SSSLoanResult | null>(null);
+interface FormState {
+  loanAmount: string;
+  annualRate: string;
+  termMonths: string;
+}
 
-  const handleCalculate = (e: React.FormEvent) => {
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  loanAmount: "",
+  annualRate: "10",
+  termMonths: "24",
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+export default function SSSLoanCalculator() {
+  const [form, formDispatch] = useReducer(formReducer, initialState);
+  const setField = useCallback(
+    (field: keyof FormState, value: string) =>
+      formDispatch({ type: "SET_FIELD", field, value }),
+    []
+  );
+
+  const {
+    data: result,
+    isLoading,
+    error,
+    calculate,
+  } = useToolCalculator<SSSLoanResult>("sss-loan");
+
+  const handleCalculate = async (e: React.FormEvent) => {
     e.preventDefault();
-    const amount = parseFloat(loanAmount);
-    const rate = parseFloat(annualRate) / 100;
-    const term = parseInt(termMonths, 10);
+    const amount = parseFloat(form.loanAmount);
+    const rate = parseFloat(form.annualRate) / 100;
+    const term = parseInt(form.termMonths, 10);
 
     if (isNaN(amount) || isNaN(rate) || isNaN(term)) return;
 
-    const res = calculateSSSLoan(amount, rate, term);
-    setResult(res);
+    await calculate({
+      loanAmount: amount,
+      annualRate: rate,
+      termMonths: term,
+    });
   };
 
   return (
@@ -50,12 +90,15 @@ export default function SSSLoanCalculator() {
                 id="sss-amount"
                 type="number"
                 placeholder="e.g. 20000"
-                value={loanAmount}
-                onChange={(e) => setLoanAmount(e.target.value)}
+                value={form.loanAmount}
+                onChange={(e) => setField("loanAmount", e.target.value)}
                 required
-                min="0"
-                step="any"
+                min={0}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                SSS salary loan amount (max depends on contributions)
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="sss-rate">Annual Rate (%)</Label>
@@ -63,12 +106,16 @@ export default function SSSLoanCalculator() {
                 id="sss-rate"
                 type="number"
                 placeholder="10"
-                value={annualRate}
-                onChange={(e) => setAnnualRate(e.target.value)}
+                value={form.annualRate}
+                onChange={(e) => setField("annualRate", e.target.value)}
                 required
-                min="0"
-                step="any"
+                min={0}
+                max={100}
+                step={0.01}
               />
+              <p className="text-xs text-muted-foreground">
+                SSS charges 10% per annum on salary loans
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="sss-term">Term (months)</Label>
@@ -76,19 +123,39 @@ export default function SSSLoanCalculator() {
                 id="sss-term"
                 type="number"
                 placeholder="24"
-                value={termMonths}
-                onChange={(e) => setTermMonths(e.target.value)}
+                value={form.termMonths}
+                onChange={(e) => setField("termMonths", e.target.value)}
                 required
-                min="1"
-                step="1"
+                min={1}
+                max={360}
+                step={1}
               />
+              <p className="text-xs text-muted-foreground">
+                Standard SSS salary loan term is 24 months
+              </p>
             </div>
           </div>
-          <Button type="submit">Calculate</Button>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
 
         {result && (
-          <div className="mt-6">
+          <div className="mt-6" role="region" aria-label="SSS loan results">
             <Card>
               <CardHeader>
                 <CardTitle className="text-base">SSS Loan Summary</CardTitle>

--- a/components/tools/tax-calculator.tsx
+++ b/components/tools/tax-calculator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useReducer } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -14,33 +14,57 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import {
-  calculateIncomeTax,
-  calculateFreelancerTax,
-  type TaxResult,
-  type FreelancerTaxComparison,
-} from "@/lib/calculators";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UpdateIcon } from "@radix-ui/react-icons";
+import { useToolCalculator } from "@/hooks/use-tool-calculator";
+import type { TaxResult, FreelancerTaxComparison } from "@/lib/calculators";
 import { formatCurrency, formatPercent } from "@/lib/client";
 
+interface FormState {
+  annualIncome: string;
+  isFreelancer: boolean;
+}
+
+type FormAction =
+  | { type: "SET_FIELD"; field: keyof FormState; value: string }
+  | { type: "SET_FREELANCER"; value: boolean }
+  | { type: "RESET" };
+
+const initialState: FormState = {
+  annualIncome: "",
+  isFreelancer: false,
+};
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "SET_FREELANCER":
+      return { ...state, isFreelancer: action.value };
+    case "RESET":
+      return initialState;
+  }
+}
+
+type TaxApiResult = TaxResult | FreelancerTaxComparison;
+
+function isFreelancerResult(result: TaxApiResult): result is FreelancerTaxComparison {
+  return "graduated" in result && "flatRate" in result && "recommended" in result;
+}
+
 export default function TaxCalculator() {
-  const [annualIncome, setAnnualIncome] = useState("");
-  const [isFreelancer, setIsFreelancer] = useState(false);
-  const [employedResult, setEmployedResult] = useState<TaxResult | null>(null);
-  const [freelancerResult, setFreelancerResult] = useState<FreelancerTaxComparison | null>(null);
+  const [form, dispatch] = useReducer(formReducer, initialState);
+  const { data: result, isLoading, error, calculate } = useToolCalculator<TaxApiResult>("tax");
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const income = parseFloat(annualIncome);
+    const income = parseFloat(form.annualIncome);
     if (isNaN(income) || income <= 0) return;
-
-    if (isFreelancer) {
-      setFreelancerResult(calculateFreelancerTax(income));
-      setEmployedResult(null);
-    } else {
-      setEmployedResult(calculateIncomeTax(income));
-      setFreelancerResult(null);
-    }
+    await calculate({ annualIncome: income, isFreelancer: form.isFreelancer });
   };
+
+  const employedResult = result && !isFreelancerResult(result) ? result : null;
+  const freelancerResult = result && isFreelancerResult(result) ? result : null;
 
   return (
     <Card>
@@ -61,19 +85,23 @@ export default function TaxCalculator() {
                 step="0.01"
                 min="0"
                 placeholder="e.g. 500000"
-                value={annualIncome}
-                onChange={(e) => setAnnualIncome(e.target.value)}
+                value={form.annualIncome}
+                onChange={(e) => dispatch({ type: "SET_FIELD", field: "annualIncome", value: e.target.value })}
                 required
               />
+              <p className="text-xs text-muted-foreground">
+                Your total annual gross income before taxes and deductions under the TRAIN law (Tax Reform for Acceleration and Inclusion).
+              </p>
             </div>
             <div className="space-y-2">
-              <Label>Employment Type</Label>
-              <div className="flex items-center gap-4 h-9">
+              <Label htmlFor="employment-type">Employment Type</Label>
+              <div className="flex items-center gap-4 h-9" id="employment-type">
                 <button
                   type="button"
-                  onClick={() => setIsFreelancer(false)}
+                  onClick={() => dispatch({ type: "SET_FREELANCER", value: false })}
+                  aria-label="Select employed tax computation"
                   className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-                    !isFreelancer
+                    !form.isFreelancer
                       ? "bg-primary text-primary-foreground shadow"
                       : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
                   }`}
@@ -82,9 +110,10 @@ export default function TaxCalculator() {
                 </button>
                 <button
                   type="button"
-                  onClick={() => setIsFreelancer(true)}
+                  onClick={() => dispatch({ type: "SET_FREELANCER", value: true })}
+                  aria-label="Select freelancer tax computation with 8% flat rate option"
                   className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-                    isFreelancer
+                    form.isFreelancer
                       ? "bg-primary text-primary-foreground shadow"
                       : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
                   }`}
@@ -92,14 +121,34 @@ export default function TaxCalculator() {
                   Self-Employed / Freelancer
                 </button>
               </div>
+              <p className="text-xs text-muted-foreground">
+                {form.isFreelancer
+                  ? "Freelancers can choose between graduated rates or the 8% flat rate on gross income exceeding ₱250,000."
+                  : "Employed individuals are taxed using the graduated TRAIN law brackets."}
+              </p>
             </div>
           </div>
-          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+          <Button type="submit" className="w-full sm:w-auto" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <UpdateIcon className="mr-2 h-4 w-4 animate-spin" />
+                Calculating...
+              </>
+            ) : (
+              "Calculate"
+            )}
+          </Button>
         </form>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
 
         {/* Employed Result */}
         {employedResult && (
-          <div className="space-y-4">
+          <div className="space-y-4" aria-label="Income tax breakdown results">
             <h4 className="text-sm font-semibold text-muted-foreground">Income Tax Breakdown</h4>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
               <div className="rounded-lg border p-3">
@@ -142,7 +191,7 @@ export default function TaxCalculator() {
 
         {/* Freelancer Result */}
         {freelancerResult && (
-          <div className="space-y-4">
+          <div className="space-y-4" aria-label="Freelancer tax comparison results">
             <h4 className="text-sm font-semibold text-muted-foreground">Tax Comparison</h4>
             <Table>
               <TableHeader>

--- a/components/tools/tax-calculator.tsx
+++ b/components/tools/tax-calculator.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import {
+  calculateIncomeTax,
+  calculateFreelancerTax,
+  type TaxResult,
+  type FreelancerTaxComparison,
+} from "@/lib/calculators";
+import { formatCurrency, formatPercent } from "@/lib/client";
+
+export default function TaxCalculator() {
+  const [annualIncome, setAnnualIncome] = useState("");
+  const [isFreelancer, setIsFreelancer] = useState(false);
+  const [employedResult, setEmployedResult] = useState<TaxResult | null>(null);
+  const [freelancerResult, setFreelancerResult] = useState<FreelancerTaxComparison | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const income = parseFloat(annualIncome);
+    if (isNaN(income) || income <= 0) return;
+
+    if (isFreelancer) {
+      setFreelancerResult(calculateFreelancerTax(income));
+      setEmployedResult(null);
+    } else {
+      setEmployedResult(calculateIncomeTax(income));
+      setFreelancerResult(null);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Tax Calculator (Philippines)</CardTitle>
+        <CardDescription>
+          Compute income tax under the TRAIN law for employed and self-employed/freelancers.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="annual-income">Annual Income</Label>
+              <Input
+                id="annual-income"
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="e.g. 500000"
+                value={annualIncome}
+                onChange={(e) => setAnnualIncome(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Employment Type</Label>
+              <div className="flex items-center gap-4 h-9">
+                <button
+                  type="button"
+                  onClick={() => setIsFreelancer(false)}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    !isFreelancer
+                      ? "bg-primary text-primary-foreground shadow"
+                      : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+                  }`}
+                >
+                  Employed
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setIsFreelancer(true)}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    isFreelancer
+                      ? "bg-primary text-primary-foreground shadow"
+                      : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+                  }`}
+                >
+                  Self-Employed / Freelancer
+                </button>
+              </div>
+            </div>
+          </div>
+          <Button type="submit" className="w-full sm:w-auto">Calculate</Button>
+        </form>
+
+        {/* Employed Result */}
+        {employedResult && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-muted-foreground">Income Tax Breakdown</h4>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+              <div className="rounded-lg border p-3">
+                <Label className="text-xs text-muted-foreground">Tax Bracket</Label>
+                <p className="text-sm font-semibold mt-1">{employedResult.bracket}</p>
+              </div>
+              <div className="rounded-lg border p-3">
+                <Label className="text-xs text-muted-foreground">Annual Tax Due</Label>
+                <p className="text-lg font-semibold text-orange-600 dark:text-orange-400">
+                  {formatCurrency(employedResult.taxDue)}
+                </p>
+              </div>
+              <div className="rounded-lg border p-3">
+                <Label className="text-xs text-muted-foreground">Effective Tax Rate</Label>
+                <p className="text-lg font-semibold">
+                  {formatPercent(employedResult.effectiveTaxRate.toFixed(2))}
+                </p>
+              </div>
+              <div className="rounded-lg border border-primary/30 bg-primary/5 p-3">
+                <Label className="text-xs text-muted-foreground">After-Tax Annual Income</Label>
+                <p className="text-lg font-bold text-primary">
+                  {formatCurrency(employedResult.afterTaxAnnual)}
+                </p>
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="rounded-lg border p-3">
+                <Label className="text-xs text-muted-foreground">Monthly Tax</Label>
+                <p className="text-lg font-semibold">{formatCurrency(employedResult.monthlyTax)}</p>
+              </div>
+              <div className="rounded-lg border border-primary/30 bg-primary/5 p-3">
+                <Label className="text-xs text-muted-foreground">Monthly After-Tax Income</Label>
+                <p className="text-lg font-bold text-primary">
+                  {formatCurrency(employedResult.afterTaxMonthly)}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Freelancer Result */}
+        {freelancerResult && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-muted-foreground">Tax Comparison</h4>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Detail</TableHead>
+                  <TableHead className="text-right">Graduated Rate</TableHead>
+                  <TableHead className="text-right">8% Flat Rate</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Annual Income</TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCurrency(freelancerResult.graduated.annualIncome)}
+                  </TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCurrency(freelancerResult.flatRate.annualIncome)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Tax Due</TableCell>
+                  <TableCell className="text-right font-medium text-orange-600 dark:text-orange-400">
+                    {formatCurrency(freelancerResult.graduated.taxDue)}
+                  </TableCell>
+                  <TableCell className="text-right font-medium text-orange-600 dark:text-orange-400">
+                    {formatCurrency(freelancerResult.flatRate.taxDue)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Effective Tax Rate</TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatPercent(freelancerResult.graduated.effectiveTaxRate.toFixed(2))}
+                  </TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatPercent(freelancerResult.flatRate.effectiveTaxRate.toFixed(2))}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>After-Tax Annual</TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCurrency(freelancerResult.graduated.afterTaxAnnual)}
+                  </TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCurrency(freelancerResult.flatRate.afterTaxAnnual)}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+
+            {/* Recommendation badge */}
+            <div className="rounded-lg border border-primary/30 bg-primary/5 p-4 text-center">
+              <p className="text-sm text-muted-foreground mb-2">Recommended Tax Option</p>
+              <Badge variant="default" className="text-sm px-4 py-1">
+                {freelancerResult.recommended === "flat" ? "8% Flat Rate" : "Graduated Rate"}
+              </Badge>
+              <p className="text-sm text-muted-foreground mt-2">
+                You save{" "}
+                <span className="font-semibold text-green-600 dark:text-green-400">
+                  {formatCurrency(
+                    Math.abs(freelancerResult.graduated.taxDue - freelancerResult.flatRate.taxDue)
+                  )}
+                </span>{" "}
+                per year with this option.
+              </p>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/use-tool-calculator.ts
+++ b/hooks/use-tool-calculator.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useReducer, useCallback } from "react";
+
+type ToolName =
+  | "affordability"
+  | "loan-comparison"
+  | "early-payoff"
+  | "rate-converter"
+  | "break-even"
+  | "in-house-loan"
+  | "salary"
+  | "tax"
+  | "debt-planner"
+  | "savings-goal"
+  | "sss-loan"
+  | "pagibig-loan"
+  | "credit-card-payoff"
+  | "car-loan"
+  | "remittance"
+  | "investment"
+  | "retirement"
+  | "emergency-fund";
+
+interface State<T> {
+  data: T | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+type Action<T> =
+  | { type: "LOADING" }
+  | { type: "SUCCESS"; payload: T }
+  | { type: "ERROR"; payload: string }
+  | { type: "RESET" };
+
+function createReducer<T>() {
+  return function reducer(state: State<T>, action: Action<T>): State<T> {
+    switch (action.type) {
+      case "LOADING":
+        return { ...state, isLoading: true, error: null };
+      case "SUCCESS":
+        return { data: action.payload, isLoading: false, error: null };
+      case "ERROR":
+        return { data: null, isLoading: false, error: action.payload };
+      case "RESET":
+        return { data: null, isLoading: false, error: null };
+    }
+  };
+}
+
+export function useToolCalculator<T>(tool: ToolName) {
+  const reducer = createReducer<T>();
+  const [state, dispatch] = useReducer(reducer, {
+    data: null,
+    isLoading: false,
+    error: null,
+  });
+
+  const calculate = useCallback(
+    async (params: Record<string, unknown>) => {
+      dispatch({ type: "LOADING" });
+      try {
+        const res = await fetch("/api/tools", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tool, params }),
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || `Request failed (${res.status})`);
+        }
+
+        const data = (await res.json()) as T;
+        dispatch({ type: "SUCCESS", payload: data });
+        return data;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Calculation failed";
+        dispatch({ type: "ERROR", payload: message });
+        return null;
+      }
+    },
+    [tool]
+  );
+
+  const reset = useCallback(() => {
+    dispatch({ type: "RESET" });
+  }, []);
+
+  return { ...state, calculate, reset };
+}

--- a/lib/calculators.ts
+++ b/lib/calculators.ts
@@ -1,0 +1,860 @@
+import { calculateRate } from "./server";
+
+// ============================================
+// Affordability Calculator (#5)
+// Given monthly budget, rate, term → max principal
+// ============================================
+export interface AffordabilityResult {
+  months: number;
+  maxPrincipal: number;
+  monthlyPayment: number;
+  totalPayment: number;
+  totalInterest: number;
+}
+
+export const calculateAffordability = (
+  monthlyBudget: number,
+  monthlyRate: number,
+  months: number,
+  processingFee: number = 0
+): AffordabilityResult => {
+  // monthly = principal * (1 + rate * months) / months
+  // principal = (monthly * months) / (1 + rate * months) - processingFee adjustment
+  const factor = 1 + monthlyRate * months;
+  const maxPrincipal = Math.floor((monthlyBudget * months - processingFee) / factor);
+  const totalInterest = maxPrincipal * monthlyRate * months;
+  const totalPayment = maxPrincipal + totalInterest + processingFee;
+  return {
+    months,
+    maxPrincipal: Math.max(0, maxPrincipal),
+    monthlyPayment: totalPayment / months,
+    totalPayment,
+    totalInterest,
+  };
+};
+
+// ============================================
+// Loan Comparison (#6)
+// Compare two bank offers
+// ============================================
+export interface LoanOffer {
+  name: string;
+  rate: number;
+  processingFee: number;
+}
+
+export interface LoanComparisonResult {
+  months: number;
+  offerA: { monthlyPayment: number; totalPayment: number; totalInterest: number };
+  offerB: { monthlyPayment: number; totalPayment: number; totalInterest: number };
+  savings: number;
+  winner: "A" | "B" | "tie";
+}
+
+export const compareLoanOffers = (
+  principal: number,
+  offerA: LoanOffer,
+  offerB: LoanOffer,
+  months: number
+): LoanComparisonResult => {
+  const calcOffer = (rate: number, fee: number) => {
+    const totalInterest = principal * rate * months;
+    const totalPayment = principal + totalInterest + fee;
+    const monthlyPayment = totalPayment / months;
+    return { monthlyPayment, totalPayment, totalInterest };
+  };
+  const a = calcOffer(offerA.rate, offerA.processingFee);
+  const b = calcOffer(offerB.rate, offerB.processingFee);
+  const savings = Math.abs(a.totalPayment - b.totalPayment);
+  const winner = a.totalPayment < b.totalPayment ? "A" : a.totalPayment > b.totalPayment ? "B" : "tie";
+  return { months, offerA: a, offerB: b, savings, winner };
+};
+
+// ============================================
+// Early Payoff Calculator (#7)
+// ============================================
+export interface EarlyPayoffResult {
+  originalMonths: number;
+  newMonths: number;
+  monthsSaved: number;
+  originalTotalInterest: number;
+  newTotalInterest: number;
+  interestSaved: number;
+  originalTotalPayment: number;
+  newTotalPayment: number;
+}
+
+export const calculateEarlyPayoff = (
+  principal: number,
+  monthlyRate: number,
+  originalMonths: number,
+  extraPayment: number,
+  processingFee: number = 0
+): EarlyPayoffResult => {
+  const originalTotalInterest = principal * monthlyRate * originalMonths;
+  const originalTotalPayment = principal + originalTotalInterest + processingFee;
+  const originalMonthly = originalTotalPayment / originalMonths;
+  const newMonthly = originalMonthly + extraPayment;
+
+  // With add-on interest (flat rate), paying extra reduces number of months
+  // totalPayment = principal + principal*rate*months + fee
+  // newMonthly * newMonths = principal + principal*rate*newMonths + fee
+  // newMonthly * newMonths = principal*(1 + rate*newMonths) + fee
+  // Solve for newMonths: newMonthly*m = principal + principal*rate*m + fee
+  // m*(newMonthly - principal*rate) = principal + fee
+  // m = (principal + fee) / (newMonthly - principal*rate)
+  const denominator = newMonthly - principal * monthlyRate;
+  let newMonths: number;
+  if (denominator <= 0) {
+    newMonths = originalMonths; // Extra payment too small to accelerate
+  } else {
+    newMonths = Math.ceil((principal + processingFee) / denominator);
+    newMonths = Math.max(1, Math.min(newMonths, originalMonths));
+  }
+
+  const newTotalInterest = principal * monthlyRate * newMonths;
+  const newTotalPayment = principal + newTotalInterest + processingFee;
+  return {
+    originalMonths,
+    newMonths,
+    monthsSaved: originalMonths - newMonths,
+    originalTotalInterest,
+    newTotalInterest,
+    interestSaved: originalTotalInterest - newTotalInterest,
+    originalTotalPayment,
+    newTotalPayment,
+  };
+};
+
+// ============================================
+// Interest Rate Converter (#8)
+// ============================================
+export interface RateConversionResult {
+  flatRateMonthly: number;
+  flatRateAnnual: number;
+  totalInterestPercent: number;
+  eirMonthly: number;
+  eirAnnual: number;
+  factorRate: number;
+}
+
+export const convertInterestRate = (flatRateMonthly: number, months: number): RateConversionResult => {
+  const totalInterestPercent = flatRateMonthly * months * 100;
+  const factorRate = (1 + flatRateMonthly * months) / months;
+  const eirMonthly = calculateRate(months, -factorRate, 1);
+  const eirAnnual = eirMonthly * 12;
+  return {
+    flatRateMonthly: flatRateMonthly * 100,
+    flatRateAnnual: flatRateMonthly * 12 * 100,
+    totalInterestPercent,
+    eirMonthly: eirMonthly * 100,
+    eirAnnual: eirAnnual * 100,
+    factorRate,
+  };
+};
+
+// ============================================
+// Break-Even Analyzer (#9)
+// ============================================
+export interface BreakEvenResult {
+  breakEvenMonth: number | null;
+  cashPrice: number;
+  installmentPriceZero: number;
+  monthlyData: Array<{
+    month: number;
+    bankTotal: number;
+    merchantTotal: number;
+    bankCheaper: boolean;
+  }>;
+}
+
+export const calculateBreakEven = (
+  cashPrice: number,
+  installmentPriceZero: number,
+  monthlyRate: number,
+  processingFee: number,
+  maxMonths: number = 36
+): BreakEvenResult => {
+  const monthlyData: BreakEvenResult["monthlyData"] = [];
+  let breakEvenMonth: number | null = null;
+
+  for (let m = 1; m <= maxMonths; m++) {
+    const bankInterest = cashPrice * monthlyRate * m;
+    const bankTotal = cashPrice + bankInterest + processingFee;
+    const merchantTotal = installmentPriceZero;
+    const bankCheaper = bankTotal < merchantTotal;
+    monthlyData.push({ month: m, bankTotal, merchantTotal, bankCheaper });
+    if (bankCheaper && breakEvenMonth === null) {
+      breakEvenMonth = m;
+    }
+  }
+  return { breakEvenMonth, cashPrice, installmentPriceZero, monthlyData };
+};
+
+// ============================================
+// In-House Loan Calculator (#10)
+// ============================================
+export interface InHouseLoanResult {
+  totalPrice: number;
+  downPayment: number;
+  loanAmount: number;
+  monthlyPayment: number;
+  totalInterest: number;
+  totalPayment: number;
+  balloonPayment: number;
+}
+
+export const calculateInHouseLoan = (
+  totalPrice: number,
+  downPaymentPercent: number,
+  monthlyRate: number,
+  months: number,
+  balloonPayment: number = 0
+): InHouseLoanResult => {
+  const downPayment = totalPrice * (downPaymentPercent / 100);
+  const loanAmount = totalPrice - downPayment - balloonPayment;
+  const totalInterest = loanAmount * monthlyRate * months;
+  const totalPayment = loanAmount + totalInterest;
+  const monthlyPayment = totalPayment / months;
+  return {
+    totalPrice,
+    downPayment,
+    loanAmount,
+    monthlyPayment,
+    totalInterest,
+    totalPayment: totalPayment + downPayment + balloonPayment,
+    balloonPayment,
+  };
+};
+
+// ============================================
+// Salary Calculator - PH (#11)
+// ============================================
+export interface SalaryBreakdown {
+  grossMonthly: number;
+  sss: number;
+  philHealth: number;
+  pagIbig: number;
+  totalContributions: number;
+  taxableIncome: number;
+  withholdingTax: number;
+  netTakeHome: number;
+}
+
+const calculateSSS = (monthlySalary: number): number => {
+  // 2024 SSS contribution table (employee share)
+  // MSC ranges from 4000 to 30000, contribution rate is 14% (split 4.5% employee, 9.5% employer)
+  // Employee share is 4.5% of MSC
+  if (monthlySalary < 4250) return 180;
+  const msc = Math.min(Math.ceil(monthlySalary / 500) * 500, 30000);
+  return msc * 0.045;
+};
+
+const calculatePhilHealth = (monthlySalary: number): number => {
+  // 2024: 5% of salary, split 50/50. Employee share = 2.5%
+  // Floor: 10000, Ceiling: 100000
+  const base = Math.max(10000, Math.min(monthlySalary, 100000));
+  return base * 0.025;
+};
+
+const calculatePagIbig = (monthlySalary: number): number => {
+  // Employee: 1% if salary ≤ 1500, 2% if > 1500, max contribution base 10000
+  // So max employee share = 200
+  if (monthlySalary <= 1500) return monthlySalary * 0.01;
+  return Math.min(monthlySalary, 10000) * 0.02;
+};
+
+const calculateWithholdingTax = (taxableIncome: number): number => {
+  // Monthly TRAIN law tax table (2023 onwards)
+  // Annual brackets divided by 12
+  const annualTaxable = taxableIncome * 12;
+  let annualTax: number;
+  if (annualTaxable <= 250000) {
+    annualTax = 0;
+  } else if (annualTaxable <= 400000) {
+    annualTax = (annualTaxable - 250000) * 0.15;
+  } else if (annualTaxable <= 800000) {
+    annualTax = 22500 + (annualTaxable - 400000) * 0.2;
+  } else if (annualTaxable <= 2000000) {
+    annualTax = 102500 + (annualTaxable - 800000) * 0.25;
+  } else if (annualTaxable <= 8000000) {
+    annualTax = 402500 + (annualTaxable - 2000000) * 0.3;
+  } else {
+    annualTax = 2202500 + (annualTaxable - 8000000) * 0.35;
+  }
+  return annualTax / 12;
+};
+
+export const calculateSalary = (grossMonthly: number): SalaryBreakdown => {
+  const sss = calculateSSS(grossMonthly);
+  const philHealth = calculatePhilHealth(grossMonthly);
+  const pagIbig = calculatePagIbig(grossMonthly);
+  const totalContributions = sss + philHealth + pagIbig;
+  const taxableIncome = grossMonthly - totalContributions;
+  const withholdingTax = calculateWithholdingTax(taxableIncome);
+  const netTakeHome = grossMonthly - totalContributions - withholdingTax;
+  return { grossMonthly, sss, philHealth, pagIbig, totalContributions, taxableIncome, withholdingTax, netTakeHome };
+};
+
+// ============================================
+// Tax Calculator - PH (#12)
+// ============================================
+export interface TaxResult {
+  annualIncome: number;
+  taxDue: number;
+  effectiveTaxRate: number;
+  bracket: string;
+  monthlyTax: number;
+  afterTaxAnnual: number;
+  afterTaxMonthly: number;
+}
+
+export interface FreelancerTaxComparison {
+  graduated: TaxResult;
+  flatRate: { annualIncome: number; taxDue: number; effectiveTaxRate: number; afterTaxAnnual: number };
+  recommended: "graduated" | "flat";
+}
+
+export const calculateIncomeTax = (annualIncome: number): TaxResult => {
+  let taxDue: number;
+  let bracket: string;
+
+  if (annualIncome <= 250000) {
+    taxDue = 0;
+    bracket = "0% (Tax-exempt)";
+  } else if (annualIncome <= 400000) {
+    taxDue = (annualIncome - 250000) * 0.15;
+    bracket = "15% (₱250K–₱400K)";
+  } else if (annualIncome <= 800000) {
+    taxDue = 22500 + (annualIncome - 400000) * 0.2;
+    bracket = "20% (₱400K–₱800K)";
+  } else if (annualIncome <= 2000000) {
+    taxDue = 102500 + (annualIncome - 800000) * 0.25;
+    bracket = "25% (₱800K–₱2M)";
+  } else if (annualIncome <= 8000000) {
+    taxDue = 402500 + (annualIncome - 2000000) * 0.3;
+    bracket = "30% (₱2M–₱8M)";
+  } else {
+    taxDue = 2202500 + (annualIncome - 8000000) * 0.35;
+    bracket = "35% (Over ₱8M)";
+  }
+
+  const effectiveTaxRate = annualIncome > 0 ? (taxDue / annualIncome) * 100 : 0;
+  return {
+    annualIncome,
+    taxDue,
+    effectiveTaxRate,
+    bracket,
+    monthlyTax: taxDue / 12,
+    afterTaxAnnual: annualIncome - taxDue,
+    afterTaxMonthly: (annualIncome - taxDue) / 12,
+  };
+};
+
+export const calculateFreelancerTax = (annualIncome: number): FreelancerTaxComparison => {
+  const graduated = calculateIncomeTax(annualIncome);
+  // 8% flat rate option (on gross income exceeding 250K)
+  const flatTaxDue = annualIncome > 250000 ? (annualIncome - 250000) * 0.08 : 0;
+  const flatRate = {
+    annualIncome,
+    taxDue: flatTaxDue,
+    effectiveTaxRate: annualIncome > 0 ? (flatTaxDue / annualIncome) * 100 : 0,
+    afterTaxAnnual: annualIncome - flatTaxDue,
+  };
+  return {
+    graduated,
+    flatRate,
+    recommended: flatTaxDue <= graduated.taxDue ? "flat" : "graduated",
+  };
+};
+
+// ============================================
+// Debt Snowball / Avalanche Planner (#13)
+// ============================================
+export interface DebtItem {
+  name: string;
+  balance: number;
+  monthlyRate: number;
+  minimumPayment: number;
+}
+
+export interface DebtPayoffResult {
+  method: "snowball" | "avalanche";
+  totalMonths: number;
+  totalPaid: number;
+  totalInterest: number;
+  order: string[];
+  schedule: Array<{
+    month: number;
+    payments: Array<{ name: string; payment: number; remaining: number }>;
+    totalRemaining: number;
+  }>;
+}
+
+export const calculateDebtPayoff = (
+  debts: DebtItem[],
+  extraPayment: number,
+  method: "snowball" | "avalanche"
+): DebtPayoffResult => {
+  // Sort debts based on method
+  const sorted = [...debts].sort((a, b) =>
+    method === "snowball" ? a.balance - b.balance : b.monthlyRate - a.monthlyRate
+  );
+
+  const balances = sorted.map((d) => d.balance);
+  const order = sorted.map((d) => d.name);
+  const schedule: DebtPayoffResult["schedule"] = [];
+  let totalPaid = 0;
+  let month = 0;
+  const maxMonths = 600; // Safety limit
+
+  while (balances.some((b) => b > 0.01) && month < maxMonths) {
+    month++;
+    let availableExtra = extraPayment;
+    const payments: DebtPayoffResult["schedule"][0]["payments"] = [];
+
+    for (let i = 0; i < sorted.length; i++) {
+      if (balances[i] <= 0) {
+        payments.push({ name: sorted[i].name, payment: 0, remaining: 0 });
+        continue;
+      }
+      // Add interest (add-on style for simplicity)
+      const interest = balances[i] * sorted[i].monthlyRate;
+      balances[i] += interest;
+      let payment = sorted[i].minimumPayment;
+
+      // Apply extra payment to the first debt with balance (priority debt)
+      const isFirstWithBalance = balances.findIndex((b) => b > 0.01) === i;
+      if (isFirstWithBalance) {
+        payment += availableExtra;
+        availableExtra = 0;
+      }
+
+      payment = Math.min(payment, balances[i]);
+      balances[i] -= payment;
+      totalPaid += payment;
+      payments.push({ name: sorted[i].name, payment, remaining: Math.max(0, balances[i]) });
+    }
+
+    schedule.push({
+      month,
+      payments,
+      totalRemaining: balances.reduce((sum, b) => sum + Math.max(0, b), 0),
+    });
+  }
+
+  const totalOriginal = debts.reduce((sum, d) => sum + d.balance, 0);
+  return { method, totalMonths: month, totalPaid, totalInterest: totalPaid - totalOriginal, order, schedule };
+};
+
+// ============================================
+// Savings Goal Calculator (#14)
+// ============================================
+export interface SavingsGoalResult {
+  targetAmount: number;
+  months: number;
+  monthlyDeposit: number;
+  totalDeposited: number;
+  totalInterestEarned: number;
+  milestones: Array<{ percent: number; month: number; amount: number }>;
+}
+
+export const calculateSavingsGoal = (
+  targetAmount: number,
+  months: number,
+  annualRate: number = 0
+): SavingsGoalResult => {
+  const monthlyRate = annualRate / 12;
+  let monthlyDeposit: number;
+
+  if (monthlyRate > 0) {
+    // FV = PMT * ((1+r)^n - 1) / r → PMT = FV * r / ((1+r)^n - 1)
+    const factor = Math.pow(1 + monthlyRate, months) - 1;
+    monthlyDeposit = (targetAmount * monthlyRate) / factor;
+  } else {
+    monthlyDeposit = targetAmount / months;
+  }
+
+  // Calculate milestones
+  const milestones: SavingsGoalResult["milestones"] = [];
+  let accumulated = 0;
+  const targets = [25, 50, 75, 100];
+  let targetIdx = 0;
+
+  for (let m = 1; m <= months && targetIdx < targets.length; m++) {
+    accumulated = accumulated * (1 + monthlyRate) + monthlyDeposit;
+    const pct = (accumulated / targetAmount) * 100;
+    if (pct >= targets[targetIdx]) {
+      milestones.push({ percent: targets[targetIdx], month: m, amount: accumulated });
+      targetIdx++;
+    }
+  }
+
+  const totalDeposited = monthlyDeposit * months;
+  return {
+    targetAmount,
+    months,
+    monthlyDeposit,
+    totalDeposited,
+    totalInterestEarned: targetAmount - totalDeposited,
+    milestones,
+  };
+};
+
+// ============================================
+// SSS Loan Calculator (#15)
+// ============================================
+export interface SSSLoanResult {
+  loanAmount: number;
+  monthlyAmortization: number;
+  totalPayment: number;
+  totalInterest: number;
+  term: number;
+}
+
+export const calculateSSSLoan = (loanAmount: number, annualRate: number = 0.1, termMonths: number = 24): SSSLoanResult => {
+  // SSS salary loan: 10% annual interest, 2-year term
+  const monthlyRate = annualRate / 12;
+  const totalInterest = loanAmount * monthlyRate * termMonths;
+  const totalPayment = loanAmount + totalInterest;
+  const monthlyAmortization = totalPayment / termMonths;
+  return { loanAmount, monthlyAmortization, totalPayment, totalInterest, term: termMonths };
+};
+
+// ============================================
+// Pag-IBIG Housing Loan Calculator (#16)
+// ============================================
+export interface PagIBIGLoanResult {
+  loanAmount: number;
+  monthlyAmortization: number;
+  totalPayment: number;
+  totalInterest: number;
+  term: number;
+  annualRate: number;
+  mri: number;
+  fireInsurance: number;
+}
+
+export const calculatePagIBIGLoan = (
+  loanAmount: number,
+  termYears: number = 30
+): PagIBIGLoanResult => {
+  // Pag-IBIG interest rates (2024):
+  // ≤ 750K: 3% for first 5 yrs, 5.375% for remaining (use blended)
+  // > 750K to 6M: 6.375%
+  let annualRate: number;
+  if (loanAmount <= 750000) {
+    annualRate = termYears <= 5 ? 0.03 : 0.04; // Blended approximation
+  } else {
+    annualRate = 0.06375;
+  }
+  const monthlyRate = annualRate / 12;
+  const termMonths = termYears * 12;
+
+  // Standard amortization: PMT = P * r * (1+r)^n / ((1+r)^n - 1)
+  const factor = Math.pow(1 + monthlyRate, termMonths);
+  const monthlyAmortization = loanAmount * (monthlyRate * factor) / (factor - 1);
+  const totalPayment = monthlyAmortization * termMonths;
+  const totalInterest = totalPayment - loanAmount;
+
+  // MRI and fire insurance estimates
+  const mri = loanAmount * 0.0025; // Approximate annual MRI
+  const fireInsurance = loanAmount * 0.001; // Approximate annual
+
+  return { loanAmount, monthlyAmortization, totalPayment, totalInterest, term: termMonths, annualRate, mri, fireInsurance };
+};
+
+// ============================================
+// Credit Card Payoff Calculator (#17)
+// ============================================
+export interface CreditCardPayoffResult {
+  balance: number;
+  minimumPaymentMonths: number;
+  minimumPaymentTotal: number;
+  minimumPaymentInterest: number;
+  fixedPaymentMonths: number;
+  fixedPaymentTotal: number;
+  fixedPaymentInterest: number;
+  timeSaved: number;
+  interestSaved: number;
+}
+
+export const calculateCreditCardPayoff = (
+  balance: number,
+  annualRate: number,
+  minimumPaymentPercent: number = 0.03,
+  minimumPaymentFloor: number = 500,
+  fixedPayment: number = 0
+): CreditCardPayoffResult => {
+  const monthlyRate = annualRate / 12;
+
+  // Calculate with minimum payments
+  let remaining = balance;
+  let minTotal = 0;
+  let minMonths = 0;
+  const maxIter = 600;
+
+  while (remaining > 0.01 && minMonths < maxIter) {
+    minMonths++;
+    const interest = remaining * monthlyRate;
+    const minPayment = Math.max(remaining * minimumPaymentPercent, minimumPaymentFloor);
+    const payment = Math.min(minPayment, remaining + interest);
+    remaining = remaining + interest - payment;
+    minTotal += payment;
+  }
+
+  // Calculate with fixed payment
+  remaining = balance;
+  let fixedTotal = 0;
+  let fixedMonths = 0;
+  const actualFixed = fixedPayment > 0 ? fixedPayment : Math.max(balance * minimumPaymentPercent, minimumPaymentFloor) * 2;
+
+  while (remaining > 0.01 && fixedMonths < maxIter) {
+    fixedMonths++;
+    const interest = remaining * monthlyRate;
+    const payment = Math.min(actualFixed, remaining + interest);
+    remaining = remaining + interest - payment;
+    fixedTotal += payment;
+  }
+
+  return {
+    balance,
+    minimumPaymentMonths: minMonths,
+    minimumPaymentTotal: minTotal,
+    minimumPaymentInterest: minTotal - balance,
+    fixedPaymentMonths: fixedMonths,
+    fixedPaymentTotal: fixedTotal,
+    fixedPaymentInterest: fixedTotal - balance,
+    timeSaved: minMonths - fixedMonths,
+    interestSaved: (minTotal - balance) - (fixedTotal - balance),
+  };
+};
+
+// ============================================
+// Car Loan Calculator (#18)
+// ============================================
+export interface CarLoanResult {
+  vehiclePrice: number;
+  downPayment: number;
+  loanAmount: number;
+  monthlyPayment: number;
+  totalInterest: number;
+  totalPayment: number;
+  chattelMortgageFee: number;
+}
+
+export const calculateCarLoan = (
+  vehiclePrice: number,
+  downPaymentPercent: number,
+  monthlyRate: number,
+  months: number
+): CarLoanResult => {
+  const downPayment = vehiclePrice * (downPaymentPercent / 100);
+  const loanAmount = vehiclePrice - downPayment;
+  // Chattel mortgage fee ~1-2% of loan
+  const chattelMortgageFee = loanAmount * 0.015;
+  const totalInterest = loanAmount * monthlyRate * months;
+  const totalPayment = loanAmount + totalInterest + chattelMortgageFee;
+  const monthlyPayment = (loanAmount + totalInterest) / months;
+  return { vehiclePrice, downPayment, loanAmount, monthlyPayment, totalInterest, totalPayment, chattelMortgageFee };
+};
+
+// ============================================
+// Forex / Remittance Calculator (#19)
+// ============================================
+export interface RemittanceResult {
+  sendAmount: number;
+  sendCurrency: string;
+  receiveAmount: number;
+  receiveCurrency: string;
+  exchangeRate: number;
+  fee: number;
+  totalCost: number;
+  effectiveRate: number;
+}
+
+export const calculateRemittance = (
+  sendAmount: number,
+  exchangeRate: number,
+  fee: number,
+  sendCurrency: string = "USD",
+  receiveCurrency: string = "PHP"
+): RemittanceResult => {
+  const totalCost = sendAmount + fee;
+  const receiveAmount = sendAmount * exchangeRate;
+  const effectiveRate = receiveAmount / totalCost;
+  return { sendAmount, sendCurrency, receiveAmount, receiveCurrency, exchangeRate, fee, totalCost, effectiveRate };
+};
+
+// ============================================
+// Investment Return Calculator (#20)
+// ============================================
+export interface InvestmentResult {
+  initialAmount: number;
+  monthlyContribution: number;
+  years: number;
+  annualReturn: number;
+  finalAmount: number;
+  totalContributed: number;
+  totalReturns: number;
+  withholdingTax: number;
+  afterTaxReturns: number;
+  yearlyBreakdown: Array<{
+    year: number;
+    balance: number;
+    contributed: number;
+    returns: number;
+  }>;
+}
+
+export const calculateInvestmentReturn = (
+  initialAmount: number,
+  monthlyContribution: number,
+  years: number,
+  annualReturn: number,
+  taxRate: number = 0.2 // 20% withholding tax on interest/dividends in PH
+): InvestmentResult => {
+  const monthlyRate = annualReturn / 12;
+  const totalMonths = years * 12;
+  let balance = initialAmount;
+  const yearlyBreakdown: InvestmentResult["yearlyBreakdown"] = [];
+
+  for (let m = 1; m <= totalMonths; m++) {
+    balance = balance * (1 + monthlyRate) + monthlyContribution;
+    if (m % 12 === 0) {
+      const year = m / 12;
+      const contributed = initialAmount + monthlyContribution * m;
+      yearlyBreakdown.push({
+        year,
+        balance,
+        contributed,
+        returns: balance - contributed,
+      });
+    }
+  }
+
+  const totalContributed = initialAmount + monthlyContribution * totalMonths;
+  const totalReturns = balance - totalContributed;
+  const withholdingTax = totalReturns * taxRate;
+  return {
+    initialAmount,
+    monthlyContribution,
+    years,
+    annualReturn,
+    finalAmount: balance,
+    totalContributed,
+    totalReturns,
+    withholdingTax,
+    afterTaxReturns: totalReturns - withholdingTax,
+    yearlyBreakdown,
+  };
+};
+
+// ============================================
+// Retirement Calculator (#21)
+// ============================================
+export interface RetirementResult {
+  currentAge: number;
+  retirementAge: number;
+  yearsToRetirement: number;
+  monthlyNeeded: number;
+  projectedFund: number;
+  targetFund: number;
+  gap: number;
+  onTrack: boolean;
+  additionalMonthlyNeeded: number;
+}
+
+export const calculateRetirement = (
+  currentAge: number,
+  retirementAge: number,
+  currentSavings: number,
+  monthlySavings: number,
+  expectedReturn: number,
+  monthlyExpenseInRetirement: number,
+  retirementDuration: number = 25 // Years of retirement
+): RetirementResult => {
+  const yearsToRetirement = retirementAge - currentAge;
+  const monthsToRetirement = yearsToRetirement * 12;
+  const monthlyRate = expectedReturn / 12;
+
+  // Project current savings + monthly contributions
+  let projectedFund = currentSavings;
+  for (let m = 0; m < monthsToRetirement; m++) {
+    projectedFund = projectedFund * (1 + monthlyRate) + monthlySavings;
+  }
+
+  // Target fund needed (present value of retirement expenses)
+  const retirementMonths = retirementDuration * 12;
+  const withdrawalRate = expectedReturn / 2 / 12; // Conservative rate during retirement
+  let targetFund: number;
+  if (withdrawalRate > 0) {
+    targetFund = monthlyExpenseInRetirement * (1 - Math.pow(1 + withdrawalRate, -retirementMonths)) / withdrawalRate;
+  } else {
+    targetFund = monthlyExpenseInRetirement * retirementMonths;
+  }
+
+  const gap = targetFund - projectedFund;
+  const onTrack = gap <= 0;
+
+  // How much more per month to close the gap
+  let additionalMonthlyNeeded = 0;
+  if (gap > 0 && monthsToRetirement > 0) {
+    if (monthlyRate > 0) {
+      const factor = Math.pow(1 + monthlyRate, monthsToRetirement) - 1;
+      additionalMonthlyNeeded = (gap * monthlyRate) / factor;
+    } else {
+      additionalMonthlyNeeded = gap / monthsToRetirement;
+    }
+  }
+
+  return {
+    currentAge,
+    retirementAge,
+    yearsToRetirement,
+    monthlyNeeded: monthlyExpenseInRetirement,
+    projectedFund,
+    targetFund,
+    gap: Math.max(0, gap),
+    onTrack,
+    additionalMonthlyNeeded,
+  };
+};
+
+// ============================================
+// Emergency Fund Calculator (#22)
+// ============================================
+export interface EmergencyFundResult {
+  monthlyExpenses: number;
+  targetMonths: number;
+  targetAmount: number;
+  currentSavings: number;
+  remaining: number;
+  monthlySavingsNeeded: number;
+  monthsToGoal: number;
+  coverageMonths: number;
+}
+
+export const calculateEmergencyFund = (
+  monthlyExpenses: number,
+  targetMonths: number = 6,
+  currentSavings: number = 0,
+  monthlySavingsCapacity: number = 0
+): EmergencyFundResult => {
+  const targetAmount = monthlyExpenses * targetMonths;
+  const remaining = Math.max(0, targetAmount - currentSavings);
+  const coverageMonths = monthlyExpenses > 0 ? currentSavings / monthlyExpenses : 0;
+  const monthlySavingsNeeded = remaining > 0 && monthlySavingsCapacity > 0 ? monthlySavingsCapacity : remaining / 12;
+  const monthsToGoal = monthlySavingsNeeded > 0 ? Math.ceil(remaining / monthlySavingsNeeded) : 0;
+
+  return {
+    monthlyExpenses,
+    targetMonths,
+    targetAmount,
+    currentSavings,
+    remaining,
+    monthlySavingsNeeded,
+    monthsToGoal,
+    coverageMonths,
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,9 @@
         "postcss": "^8",
         "tailwindcss": "^3.3.0",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/schema/index.ts
+++ b/schema/index.ts
@@ -8,7 +8,17 @@ export const CalculateFormSchema = z
       .number()
       .transform((value) => value / 100) // Convert percentage to decimal
       .refine((val) => !isNaN(val) && val >= 0 && val <= 1, "Interest rate must be a percentage between 0% and 100%"),
-    numInstallments: z.enum(["3", "6", "9", "12", "15", "18", "21", "24", "27", "30", "33", "36"]).default("3"),
+    numInstallments: z
+      .string()
+      .refine(
+        (val) => {
+          const num = parseInt(val);
+          return !isNaN(num) && num >= 1 && num <= 360;
+        },
+        "Must be between 1 and 360 months"
+      )
+      .default("3"),
+    customPlanList: z.array(z.string()).optional(),
     processingFee: z.coerce.number().min(0).optional(),
     installmentAmount: z.coerce.number().min(0),
     monthlyBudget: z.coerce.number().min(0).optional(),


### PR DESCRIPTION
- Enhance card-form with Preset/Custom/Range/Quick Fill month input modes
  and advanced comparison plan customizer
- Relax numInstallments schema to accept 1-360 months with customPlanList
- Add /tools page with 18 categorized financial calculators (loans, credit,
  income/tax, planning/savings) including PH-specific tools (SSS, Pag-IBIG,
  TRAIN law tax, salary breakdown)
- Add calculator utility functions in lib/calculators.ts
- Update navbar with Financial Tools link for desktop and mobile

https://claude.ai/code/session_01944FnofkbkjYT2nkk1hZhP