### PR TITLE
feat: switch to Plus Jakarta Sans, set light default theme, rewrite docs for 3 live tools

### DIFF
--- a/app/bank-conversion-list/page.tsx
+++ b/app/bank-conversion-list/page.tsx
@@ -46,7 +46,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
   return (
-    <h2 className="font-display italic font-light text-xl tracking-tight mb-3">
+    <h2 className="font-display font-light text-xl tracking-tight mb-3">
       {children}
     </h2>
   );
@@ -111,7 +111,7 @@ export default function Page() {
         <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-3">
           Reference
         </p>
-        <h1 className="font-display italic font-light text-3xl sm:text-4xl tracking-tight">
+        <h1 className="font-display font-extralight text-3xl sm:text-4xl tracking-[-0.03em]">
           Financial Products List
         </h1>
         <p className="mt-3 text-sm text-muted-foreground leading-relaxed">

--- a/app/bank-conversion-list/page.tsx
+++ b/app/bank-conversion-list/page.tsx
@@ -98,6 +98,12 @@ function DocSection({ children }: { children: React.ReactNode }) {
   return <div className="space-y-1 pb-10">{children}</div>;
 }
 
+function SourceNote({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-[10px] text-muted-foreground/60 mt-1 leading-relaxed">{children}</p>
+  );
+}
+
 export default function Page() {
   return (
     <div className="container mx-auto px-4 py-10 max-w-4xl">
@@ -141,6 +147,7 @@ export default function Page() {
         <Body>
           Promo rates (as low as 0.49%) are typically invite-only or limited-time.
         </Body>
+        <SourceNote>Sources: BSP Circular No. 1098 (2020), No. 1165 (2023), and bank-published fee schedules. As of 2026.</SourceNote>
       </DocSection>
 
       <div className="h-px bg-border opacity-30 mb-10" />
@@ -162,6 +169,7 @@ export default function Page() {
           ]}
         />
         <Body>Processing fees typically range from ₱250–₱500 per availment.</Body>
+        <SourceNote>Sources: Bank-published fee schedules and cardholder agreements. As of 2026.</SourceNote>
       </DocSection>
 
       <div className="h-px bg-border opacity-30 mb-10" />
@@ -186,6 +194,7 @@ export default function Page() {
             ["PNB", "ZAPP", "24 months", "Varies"],
           ]}
         />
+        <SourceNote>Sources: Bank-published fee schedules and merchant partner programs. As of 2026.</SourceNote>
       </DocSection>
 
       <div className="h-px bg-border opacity-50 mb-10" />
@@ -209,6 +218,7 @@ export default function Page() {
             ["Tonik", "~1.79%–3.46%", "Varies", "6–24 months", "None", "₱250K"],
           ]}
         />
+        <SourceNote>Sources: Bank-published rate tables and BSP Circular No. 1098. As of 2026.</SourceNote>
       </DocSection>
 
       <div className="h-px bg-border opacity-50 mb-10" />
@@ -236,6 +246,7 @@ export default function Page() {
           Effective interest rate is higher than the stated 10% p.a. because interest is computed
           on the full original principal, not on the declining balance.
         </Body>
+        <SourceNote>Source: SSS.gov.ph official rate schedule. As of 2026.</SourceNote>
       </DocSection>
 
       <div className="h-px bg-border opacity-30 mb-10" />
@@ -271,6 +282,7 @@ export default function Page() {
             ["Amortization Formula", "PMT = P × [r(1+r)^n] / [(1+r)^n − 1] (declining balance)"],
           ]}
         />
+        <SourceNote>Source: HDMF (Pag-IBIG Fund) official rate table. As of 2026.</SourceNote>
       </DocSection>
 
       <div className="h-px bg-border opacity-50 mb-10" />
@@ -292,9 +304,10 @@ export default function Page() {
             ["Metrobank", "0.5%–1.2% flat", "20–30%", "12–60 months", "~1.5% of loan"],
             ["Security Bank", "Personalized", "20–30%", "12–60 months", "~1.5% of loan"],
             ["UnionBank", "Personalized", "20–30%", "12–60 months", "~1.5% of loan"],
-            ["In-house (dealers)", "1.0%–2.0% flat", "20–40%", "12–60 months", "Included"],
+            ["In-house (dealers)", "1.5%–2.5% flat", "20–40%", "12–60 months", "Included"],
           ]}
         />
+        <SourceNote>Sources: Bank-published rates and dealer financing disclosures. As of 2026.</SourceNote>
       </DocSection>
 
       <div className="h-px bg-border opacity-30 mb-10" />
@@ -316,6 +329,7 @@ export default function Page() {
             ["Security Bank", "5.75%–7.75% p.a.", "20 years", "Varies"],
           ]}
         />
+        <SourceNote>Sources: Bank-published mortgage rate tables. As of 2026.</SourceNote>
       </DocSection>
 
       <div className="h-px bg-border opacity-50 mb-10" />

--- a/app/calculator/page.tsx
+++ b/app/calculator/page.tsx
@@ -73,7 +73,7 @@ export default function CalculatorPage() {
         <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-2">
           Tool
         </p>
-        <h1 className="font-display italic font-light text-3xl sm:text-4xl lg:text-5xl tracking-tight">
+        <h1 className="font-display font-extralight text-3xl sm:text-4xl lg:text-5xl tracking-[-0.03em]">
           Installment Calculator
         </h1>
         <p className="mt-3 text-sm sm:text-base text-muted-foreground leading-relaxed">
@@ -127,7 +127,7 @@ function EmptyState() {
       <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-3">
         No calculation yet
       </p>
-      <h2 className="font-display italic font-light text-xl sm:text-2xl mb-2">
+      <h2 className="font-display font-light text-xl sm:text-2xl mb-2">
         Enter your details to begin
       </h2>
       <p className="text-sm text-muted-foreground max-w-md mx-auto leading-relaxed">

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -42,7 +42,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
   return (
-    <h2 className="font-display italic font-light text-xl tracking-tight mb-3">
+    <h2 className="font-display font-light text-xl tracking-tight mb-3">
       {children}
     </h2>
   );
@@ -87,7 +87,7 @@ export default function Page() {
         <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-3">
           Reference
         </p>
-        <h1 className="font-display italic font-light text-3xl sm:text-4xl tracking-tight">
+        <h1 className="font-display font-extralight text-3xl sm:text-4xl tracking-[-0.03em]">
           Documentation
         </h1>
         <p className="mt-3 text-sm text-muted-foreground leading-relaxed">

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,30 +1,32 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Savvy Spender - Payment Calculator Documentation",
+  title: "Savvy Spender - Documentation",
   description:
-    "Learn how payment calculations work with Savvy Spender's Payment Calculator Documentation. Understand the details behind calculating payments and comparing options.",
+    "How each calculator works — inputs, formulas, and what the results mean. Covers the Installment Calculator, Card FX Comparison, and Loan Comparison tools.",
   keywords: [
     "Payment Calculator Documentation",
-    "Calculating Payments",
-    "Payment Calculation Explained",
-    "Payment Comparison Documentation",
-    "Financial Calculations",
+    "Installment Calculator Documentation",
+    "Card FX Comparison Documentation",
+    "Loan Comparison Documentation",
+    "Balance Conversion Calculator",
+    "Credit-to-Cash Calculator",
+    "Financial Calculations Philippines",
   ],
-  metadataBase: new URL("https://www.savvyspendercalculator.com/"),
-  applicationName: "Savvy Spender Calculator",
+  metadataBase: new URL("https://www.savvyspender.info/"),
+  applicationName: "Savvy Spender",
   openGraph: {
     type: "website",
-    url: "https://www.savvyspendercalculator.com/",
-    title: "Savvy Spender - Payment Calculator Documentation",
+    url: "https://www.savvyspender.info/docs",
+    title: "Savvy Spender - Documentation",
     description:
-      "Learn how payment calculations work with Savvy Spender's Payment Calculator Documentation. Understand the details behind calculating payments and comparing options.",
+      "How each calculator works — inputs, formulas, and what the results mean.",
   },
   twitter: {
-    site: "https://www.savvyspendercalculator.com/",
-    title: "Savvy Spender - Payment Calculator Documentation",
+    site: "https://www.savvyspender.info/",
+    title: "Savvy Spender - Documentation",
     description:
-      "Learn how payment calculations work with Savvy Spender's Payment Calculator Documentation. Understand the details behind calculating payments and comparing options.",
+      "How each calculator works — inputs, formulas, and what the results mean.",
   },
   referrer: "no-referrer-when-downgrade",
   formatDetection: { telephone: false },
@@ -94,9 +96,9 @@ export default function Page() {
       </div>
       <div className="h-px bg-border opacity-50 mb-10" />
 
-      {/* Installment & Credit Card */}
+      {/* ── Installment Calculator ─────────────────────────────────── */}
       <DocSection>
-        <SectionLabel>Installment &amp; Credit Card</SectionLabel>
+        <SectionLabel>Installment Calculator</SectionLabel>
         <SectionTitle>How Add-On Interest Works</SectionTitle>
         <Body>
           Philippine banks charge interest on the original principal for the entire term — not on
@@ -118,11 +120,12 @@ export default function Page() {
       <div className="h-px bg-border opacity-30 mb-10" />
 
       <DocSection>
-        <SectionLabel>Installment &amp; Credit Card</SectionLabel>
+        <SectionLabel>Installment Calculator</SectionLabel>
         <SectionTitle>Balance Conversion</SectionTitle>
         <Body>
-          Converts existing credit card purchases into fixed monthly installments. You choose a term
-          and the bank applies an add-on rate to your balance.
+          Converts existing credit card purchases or outstanding balances into fixed monthly
+          installments using the add-on interest method. You choose a term and the bank applies a
+          flat rate to your balance.
         </Body>
         <SubTitle>Inputs</SubTitle>
         <Body>
@@ -141,12 +144,21 @@ export default function Page() {
       <div className="h-px bg-border opacity-30 mb-10" />
 
       <DocSection>
-        <SectionLabel>Installment &amp; Credit Card</SectionLabel>
+        <SectionLabel>Installment Calculator</SectionLabel>
         <SectionTitle>Credit-to-Cash</SectionTitle>
         <Body>
           Converts available (unused) credit limit into cash deposited to your account. Known as
           Cash2Go (Metrobank), Ready Cash (Security Bank), YourCash (RCBC), or CashLite depending
           on the bank. The math is identical to Balance Conversion — only the context differs.
+        </Body>
+        <SubTitle>Inputs</SubTitle>
+        <Body>
+          Cash amount needed, monthly add-on rate (%), term, optional processing fee, optional
+          monthly budget.
+        </Body>
+        <SubTitle>Outputs</SubTitle>
+        <Body>
+          Monthly payment, total interest, factor rate, and effective interest rate (EIR).
         </Body>
         <Body>
           Typical rates: 0.49%–1.00% monthly add-on. Terms up to 60 months. Processing fee
@@ -157,7 +169,7 @@ export default function Page() {
       <div className="h-px bg-border opacity-30 mb-10" />
 
       <DocSection>
-        <SectionLabel>Installment &amp; Credit Card</SectionLabel>
+        <SectionLabel>Installment Calculator</SectionLabel>
         <SectionTitle>Personal Loan</SectionTitle>
         <Body>
           Standalone unsecured bank loans, separate from credit cards. The key difference is
@@ -176,342 +188,132 @@ export default function Page() {
 
       <div className="h-px bg-border opacity-50 mb-10" />
 
-      {/* Loan Calculators */}
+      {/* ── Card FX Comparison ────────────────────────────────────── */}
       <DocSection>
-        <SectionLabel>Loans</SectionLabel>
-        <SectionTitle>Affordability Calculator</SectionTitle>
+        <SectionLabel>Card FX Comparison</SectionLabel>
+        <SectionTitle>How Foreign Transaction Markups Work</SectionTitle>
         <Body>
-          Reverses the standard loan formula: instead of computing the payment from a loan amount,
-          it finds the maximum loan amount from a monthly budget.
+          When you pay in a foreign currency, your card issuer converts the amount to PHP using a
+          rate marked up above the interbank (wholesale) rate. The all-in cost combines two
+          charges: a bank-imposed forex conversion fee and a network cross-border assessment fee
+          added by Visa or Mastercard.
         </Body>
         <Formula>
-          <div>factor = 1 + (monthlyRate × months)</div>
-          <div>maxPrincipal = (monthlyBudget × months − fee) / factor</div>
+          <div>PHP Cost = Foreign Amount × PHP-per-unit × (1 + fxMarkup / 100)</div>
         </Formula>
         <Body>
-          Results appear across multiple terms simultaneously, showing how much more or less you can
-          borrow at each length.
+          Visa adds ~1% and Mastercard ~0.2–1% as their network assessment. Most banks bundle
+          these into a single quoted markup. Cards advertised as &quot;0% forex&quot; waive the
+          bank fee — the network assessment may still apply.
         </Body>
       </DocSection>
 
       <div className="h-px bg-border opacity-30 mb-10" />
 
       <DocSection>
-        <SectionLabel>Loans</SectionLabel>
-        <SectionTitle>Loan Comparison</SectionTitle>
+        <SectionLabel>Card FX Comparison</SectionLabel>
+        <SectionTitle>Live Reference Rate</SectionTitle>
         <Body>
-          Puts two bank loan offers side by side across the same set of terms. Compares monthly
-          payment, total interest, total cost including processing fee, savings between the two, and
-          winner at each term. Use this when you have competing offers and want to see the true
-          difference over time.
-        </Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Loans</SectionLabel>
-        <SectionTitle>Early Payoff Calculator</SectionTitle>
-        <Body>
-          Shows the effect of adding extra monthly payments on top of your regular installment. With
-          add-on interest, extra payments reduce the number of months remaining — which reduces total
-          interest paid.
+          The base PHP-per-unit rate is fetched live from open exchange rate APIs. Three sources
+          are tried in order, and the first successful response is used:
         </Body>
         <Formula>
-          <div>newMonthly = originalMonthly + extraPayment</div>
-          <div>newMonths = (principal + fee) / (newMonthly − principal × rate)</div>
-          <div>interestSaved = principal × rate × (originalMonths − newMonths)</div>
-        </Formula>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Loans</SectionLabel>
-        <SectionTitle>In-House Loan Calculator</SectionTitle>
-        <Body>
-          For developer or dealer direct financing. Handles the distinct structure: a percentage
-          down payment, a loan amount on the remainder, flat-rate monthly payments, and an optional
-          balloon payment due at the end of term.
-        </Body>
-        <Body>
-          Common for real estate developers and vehicle dealers offering their own financing, often
-          with higher rates but more flexible credit requirements.
-        </Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Loans</SectionLabel>
-        <SectionTitle>SSS Salary Loan</SectionTitle>
-        <Body>
-          Computes SSS (Social Security System) salary loan amortization. The SSS charges 10% per
-          annum on the original principal (add-on / flat method), standard term is 24 months.
-        </Body>
-        <Formula>
-          <div>monthlyRate = 10% / 12</div>
-          <div>totalInterest = loanAmount × monthlyRate × termMonths</div>
-          <div>monthlyAmortization = (loanAmount + totalInterest) / termMonths</div>
+          <div>1. open.er-api.com — returns time_last_update_utc</div>
+          <div>2. api.frankfurter.app — returns date</div>
+          <div>3. cdn.jsdelivr.net/@fawazahmed0/currency-api — returns date</div>
         </Formula>
         <Body>
-          The effective rate is higher than 10% p.a. because interest is calculated on the full
-          principal throughout the term, not on the declining balance.
+          Rates are cached server-side for 1 hour (Next.js revalidation). The sidebar shows
+          which source responded and when the rate was last updated. This is a reference rate —
+          your actual billing rate may differ slightly from what your bank applies.
         </Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Loans</SectionLabel>
-        <SectionTitle>Pag-IBIG Housing Loan</SectionTitle>
-        <Body>
-          Unlike most Philippine installment products, Pag-IBIG housing loans use declining balance
-          amortization — you pay less interest over time as your principal is paid down.
-        </Body>
-        <Formula>
-          <div>PMT = P × [r(1+r)^n] / [(1+r)^n − 1]</div>
-          <div>where P = principal, r = monthly rate, n = total months</div>
-        </Formula>
-        <Body>
-          Additional monthly costs include MRI (Mortgage Redemption Insurance, ~0.25% of loan
-          annually) and fire insurance (~0.10% annually). Rates as of 2024: loans ≤ ₱750K start at
-          3% for the first 5 years; loans above ₱750K up to ₱6M are at 6.375% fixed.
-        </Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Loans</SectionLabel>
-        <SectionTitle>Car Loan Calculator</SectionTitle>
-        <Body>
-          Philippine auto loans use add-on (flat) interest. All bank-financed vehicles require a
-          chattel mortgage registered with the LTO — typically 1–2% of the loan amount added to the
-          total cost.
-        </Body>
-        <Formula>
-          <div>loan = vehiclePrice − downPayment</div>
-          <div>interest = loan × rate × months</div>
-          <div>monthlyPayment = (loan + interest) / months</div>
-        </Formula>
-        <Body>Typical down payment: 20–30% of vehicle price.</Body>
       </DocSection>
 
       <div className="h-px bg-border opacity-50 mb-10" />
 
-      {/* Credit & Rates */}
+      {/* ── Loan Comparison ───────────────────────────────────────── */}
       <DocSection>
-        <SectionLabel>Credit &amp; Rates</SectionLabel>
-        <SectionTitle>Interest Rate Converter</SectionTitle>
+        <SectionLabel>Loan Comparison</SectionLabel>
+        <SectionTitle>Three Financing Options</SectionTitle>
         <Body>
-          Converts between flat (add-on) rates and effective interest rates (EIR). Philippine banks
-          advertise add-on rates — the true cost is always higher.
+          The Loan Comparison tool puts three ways to finance a vehicle or asset side by side:
+          In-House Financing, Bank Auto Loan, and Credit-to-Cash. All three use the add-on
+          (flat-rate) interest method.
         </Body>
+        <Formula>
+          <div>Loan Amount = Asset Price − Down Payment</div>
+          <div>Total Interest = Loan × Monthly Rate × Term Months</div>
+          <div>Monthly Payment = (Loan + Total Interest + Fees) / Term Months</div>
+        </Formula>
         <Body>
-          Typical conversions: 0.99%/month flat ≈ 21–23% EIR p.a. — 1.25%/month flat ≈ 27–29%
-          EIR p.a. Outputs flat rate, total interest %, EIR monthly and annual, and factor rate.
-        </Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Credit &amp; Rates</SectionLabel>
-        <SectionTitle>Break-Even Analyzer</SectionTitle>
-        <Body>
-          Finds the term at which a bank installment plan becomes cheaper than a merchant&apos;s 0%
-          plan. Merchant 0% plans typically have a marked-up total price. At shorter terms the bank
-          may cost less; as months increase, accumulated interest may push the bank plan past the
-          merchant price. A chart shows the exact crossover point.
+          The effective interest rate (EIR) is computed via Newton-Raphson to find the internal
+          rate of return that equates all cash flows to the loan amount received.
         </Body>
       </DocSection>
 
       <div className="h-px bg-border opacity-30 mb-10" />
 
       <DocSection>
-        <SectionLabel>Credit &amp; Rates</SectionLabel>
-        <SectionTitle>Credit Card Payoff</SectionTitle>
+        <SectionLabel>Loan Comparison</SectionLabel>
+        <SectionTitle>In-House Financing</SectionTitle>
         <Body>
-          Compares minimum payments vs. a fixed higher payment for clearing an existing credit card
-          balance. With minimum payments, as your balance drops your payment drops too — making it
-          very slow to clear. A fixed payment stays effective throughout.
+          Direct financing from a car dealer or real estate developer. No bank credit check is
+          required, making it accessible to buyers who don&apos;t qualify for bank loans. The
+          tradeoff is a significantly higher monthly rate (typically 1.5%–2.5% flat per month).
+        </Body>
+        <Body>
+          A down payment is required (typically 20–40%). The chattel mortgage is usually handled
+          by the dealer and bundled into the price rather than charged as a separate fee.
+        </Body>
+      </DocSection>
+
+      <div className="h-px bg-border opacity-30 mb-10" />
+
+      <DocSection>
+        <SectionLabel>Loan Comparison</SectionLabel>
+        <SectionTitle>Bank Auto Loan</SectionTitle>
+        <Body>
+          Secured loan from a bank, using the vehicle as collateral. Offers the lowest monthly
+          rate among the three options (typically 0.47%–0.98% flat per month), but requires a
+          credit check, comprehensive car insurance, and a chattel mortgage registered with the
+          LTO.
+        </Body>
+        <SubTitle>Additional Fees</SubTitle>
+        <Formula>
+          <div>Chattel Mortgage: registered with LTO, typically ~1–2% of loan amount</div>
+          <div>Processing Fee: typically ₱2,000–₱3,500 depending on bank</div>
+          <div>Total Cost = Down Payment + Loan + Total Interest + All Fees</div>
+        </Formula>
+      </DocSection>
+
+      <div className="h-px bg-border opacity-30 mb-10" />
+
+      <DocSection>
+        <SectionLabel>Loan Comparison</SectionLabel>
+        <SectionTitle>Credit-to-Cash for Vehicle Purchase</SectionTitle>
+        <Body>
+          Uses available credit card limit as the funding source instead of a traditional loan.
+          No down payment, no collateral, and no asset ownership transfer is involved — you
+          simply borrow against your existing credit line.
+        </Body>
+        <Body>
+          The BSP caps the monthly add-on rate at 1.00% for credit card installment programs.
+          Maximum amount is limited by your available credit limit, which may be less than the
+          full vehicle price.
         </Body>
         <Note>
-          Credit cards use declining balance interest (charged on remaining balance each month),
-          unlike installment loans which use add-on / flat rates. Typical PH credit card rate:
-          24–36% p.a.
+          Because there is no down payment, the full asset price becomes the loan amount — which
+          means total interest paid is higher than the bank loan option despite a similar stated
+          rate.
         </Note>
       </DocSection>
 
       <div className="h-px bg-border opacity-50 mb-10" />
 
-      {/* Income & Tax */}
-      <DocSection>
-        <SectionLabel>Income &amp; Tax</SectionLabel>
-        <SectionTitle>Salary Calculator</SectionTitle>
-        <Body>
-          Computes net monthly take-home pay after all mandatory deductions under 2024 Philippine
-          contribution tables and the TRAIN law.
-        </Body>
-        <SubTitle>Deduction order</SubTitle>
-        <Formula>
-          <div>1. SSS — 4.5% of MSC (max MSC ₱30,000)</div>
-          <div>2. PhilHealth — 2.5% of salary (floor ₱10K, ceiling ₱100K)</div>
-          <div>3. Pag-IBIG — 2% up to ₱10,000 base (max ₱200)</div>
-          <div>4. Taxable Income = Gross − Total Contributions</div>
-          <div>5. Withholding Tax — TRAIN law graduated brackets</div>
-        </Formula>
-        <SubTitle>TRAIN Law Brackets (Annual)</SubTitle>
-        <div className="border border-border rounded text-xs font-mono overflow-x-auto my-3">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-border bg-muted/30">
-                <th className="text-left px-3 py-2 font-mono-label text-[10px] uppercase tracking-[0.1em]">Annual Income</th>
-                <th className="text-left px-3 py-2 font-mono-label text-[10px] uppercase tracking-[0.1em]">Tax</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border text-muted-foreground">
-              <tr><td className="px-3 py-1.5">≤ ₱250,000</td><td className="px-3 py-1.5">0% (exempt)</td></tr>
-              <tr><td className="px-3 py-1.5">₱250K–₱400K</td><td className="px-3 py-1.5">15% of excess over ₱250K</td></tr>
-              <tr><td className="px-3 py-1.5">₱400K–₱800K</td><td className="px-3 py-1.5">₱22,500 + 20% of excess</td></tr>
-              <tr><td className="px-3 py-1.5">₱800K–₱2M</td><td className="px-3 py-1.5">₱102,500 + 25% of excess</td></tr>
-              <tr><td className="px-3 py-1.5">₱2M–₱8M</td><td className="px-3 py-1.5">₱402,500 + 30% of excess</td></tr>
-              <tr><td className="px-3 py-1.5">Over ₱8M</td><td className="px-3 py-1.5">₱2,202,500 + 35% of excess</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Income &amp; Tax</SectionLabel>
-        <SectionTitle>Tax Calculator</SectionTitle>
-        <Body>
-          Computes income tax for both employed and self-employed / freelancers. Freelancers can
-          compare two methods: the standard graduated brackets, or the 8% flat rate on gross income
-          exceeding ₱250,000. The 8% flat rate is generally better for freelancers earning under
-          ~₱3M per year. The calculator compares both and recommends the lower option.
-        </Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-50 mb-10" />
-
-      {/* Planning & Savings */}
-      <DocSection>
-        <SectionLabel>Planning &amp; Savings</SectionLabel>
-        <SectionTitle>Debt Snowball / Avalanche Planner</SectionTitle>
-        <Body>
-          For managing multiple debts simultaneously. Compares two proven payoff strategies:
-          Snowball (smallest balance first — quick wins keep motivation high) and Avalanche (highest
-          interest rate first — saves the most money overall).
-        </Body>
-        <Body>
-          Enter each debt&apos;s name, balance, monthly rate, and minimum payment, plus your total
-          extra monthly payment capacity. Outputs: months to debt freedom, total interest paid,
-          payoff order, and a month-by-month schedule.
-        </Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Planning &amp; Savings</SectionLabel>
-        <SectionTitle>Savings Goal Calculator</SectionTitle>
-        <Body>
-          Calculates the monthly deposit needed to reach a savings target, with optional compound
-          interest.
-        </Body>
-        <Formula>
-          <div>With interest: PMT = Target × r / [(1+r)^n − 1]</div>
-          <div>Without interest: PMT = Target / months</div>
-        </Formula>
-        <Body>Shows milestones at 25%, 50%, 75%, and 100% of goal.</Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Planning &amp; Savings</SectionLabel>
-        <SectionTitle>Retirement Calculator</SectionTitle>
-        <Body>
-          Projects whether your current savings rate will cover retirement expenses. Computes your
-          projected fund (current savings + contributions + returns) against the target fund needed
-          to fund monthly withdrawals throughout retirement (present value of annuity formula). If
-          there is a gap, shows how much additional monthly savings would close it.
-        </Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Planning &amp; Savings</SectionLabel>
-        <SectionTitle>Emergency Fund Calculator</SectionTitle>
-        <Body>
-          Determines your target emergency fund based on monthly expenses and risk profile, then
-          tracks your progress toward it.
-        </Body>
-        <div className="border border-border rounded text-xs font-mono overflow-x-auto my-3">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-border bg-muted/30">
-                <th className="text-left px-3 py-2 font-mono-label text-[10px] uppercase tracking-[0.1em]">Situation</th>
-                <th className="text-left px-3 py-2 font-mono-label text-[10px] uppercase tracking-[0.1em]">Recommended</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border text-muted-foreground">
-              <tr><td className="px-3 py-1.5">Stable job, no dependents</td><td className="px-3 py-1.5">3 months</td></tr>
-              <tr><td className="px-3 py-1.5">Average risk</td><td className="px-3 py-1.5">6 months</td></tr>
-              <tr><td className="px-3 py-1.5">Self-employed / variable income</td><td className="px-3 py-1.5">9–12 months</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Planning &amp; Savings</SectionLabel>
-        <SectionTitle>Remittance Calculator</SectionTitle>
-        <Body>
-          For OFWs sending money home. Shows the effective exchange rate — the combined impact of
-          the posted exchange rate and the transfer fee, expressed as a single comparable number.
-        </Body>
-        <Formula>
-          <div>receiveAmount = sendAmount × exchangeRate</div>
-          <div>effectiveRate = receiveAmount / (sendAmount + fee)</div>
-        </Formula>
-        <Body>
-          Use this to compare remittance services. A high exchange rate can be offset by a high fee,
-          and vice versa. The effective rate captures both.
-        </Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-30 mb-10" />
-
-      <DocSection>
-        <SectionLabel>Planning &amp; Savings</SectionLabel>
-        <SectionTitle>Investment Returns Calculator</SectionTitle>
-        <Body>
-          Projects investment growth with compound returns and regular monthly contributions.
-          Applies the Philippine 20% final withholding tax on gains.
-        </Body>
-        <Formula>
-          <div>each month: balance = balance × (1 + monthlyRate) + contribution</div>
-        </Formula>
-        <Body>
-          Outputs: final portfolio value, total contributed, total returns, after-tax returns, and a
-          year-by-year breakdown.
-        </Body>
-      </DocSection>
-
-      <div className="h-px bg-border opacity-50 mb-10" />
-
       <p className="text-xs text-muted-foreground leading-relaxed">
-        All calculations are for reference purposes only. Rates, fees, contribution tables, and
-        regulatory requirements change over time. Always verify details directly with the relevant
-        government agency, bank, or financial institution before making any financial decision.
+        All calculations are for reference purposes only. Rates, fees, and regulatory requirements
+        change over time. Always verify details directly with the relevant bank or financial
+        institution before making any financial decision.
       </p>
     </div>
   );

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -13,7 +13,7 @@ const ErrorComponent: React.FC<ErrorProps> = ({ error, reset }) => {
   return (
     <div className="flex min-h-[60vh] items-center justify-center px-4">
       <div className="max-w-sm text-center space-y-4">
-        <h1 className="font-display italic font-light text-3xl">Something went wrong</h1>
+        <h1 className="font-display font-light text-3xl">Something went wrong</h1>
         <p className="text-sm text-muted-foreground">{error.message}</p>
         <div className="flex flex-col gap-2 pt-2">
           <button

--- a/app/fx-compare/page.tsx
+++ b/app/fx-compare/page.tsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
-import { CARD_FX_DATA, type CardFxEntry } from "@/constant/fx-data";
+import { CARD_FX_DATA, CARD_FX_DATA_REVIEWED, type CardFxEntry } from "@/constant/fx-data";
 import type { FxRatesResponse } from "@/app/api/fx-rates/route";
 
 /* ── Types ─────────────────────────────────────────────────────────── */
@@ -204,6 +204,9 @@ export default function FxComparePage() {
             <p>
               Visa adds a ~1% cross-border assessment and Mastercard ~0.2%, typically bundled into the bank&apos;s quoted markup.
               Always verify with your card issuer before travel.
+            </p>
+            <p className="border-t pt-2 text-[10px] opacity-60">
+              Bank markup data last reviewed: {CARD_FX_DATA_REVIEWED}. Sources: bank fee schedules, cardholder agreements, BSP filings.
             </p>
           </div>
         </aside>

--- a/app/fx-compare/page.tsx
+++ b/app/fx-compare/page.tsx
@@ -100,7 +100,7 @@ export default function FxComparePage() {
         <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-2">
           Tool
         </p>
-        <h1 className="font-display italic font-light text-3xl sm:text-4xl lg:text-5xl tracking-tight">
+        <h1 className="font-display font-extralight text-3xl sm:text-4xl lg:text-5xl tracking-[-0.03em]">
           Card FX Comparison
         </h1>
         <p className="mt-3 text-sm sm:text-base text-muted-foreground leading-relaxed">
@@ -117,7 +117,7 @@ export default function FxComparePage() {
               <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
                 Simulator
               </p>
-              <CardTitle className="font-display italic font-light text-xl tracking-tight mt-0.5">
+              <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
                 Amount & Currency
               </CardTitle>
             </CardHeader>
@@ -220,7 +220,7 @@ export default function FxComparePage() {
                   <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
                     Card Comparison
                   </p>
-                  <CardTitle className="font-display italic font-light text-xl tracking-tight mt-0.5">
+                  <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
                     {foreignAmount > 0 && phpPerUnit
                       ? `${selectedCurrency} ${foreignAmount.toLocaleString()} → PHP`
                       : "FX Markup by Issuer"}

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,77 +4,80 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* Warm off-white background; near-black warm foreground — editorial feel */
+    --background: 40 20% 98.5%;
+    --foreground: 30 10% 10%;
 
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card: 40 20% 99%;
+    --card-foreground: 30 10% 10%;
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover: 40 20% 99%;
+    --popover-foreground: 30 10% 10%;
 
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
+    /* Subtle restrained accent — not a saturated brand blue */
+    --primary: 30 10% 10%;
+    --primary-foreground: 40 20% 98.5%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 35 15% 94%;
+    --secondary-foreground: 30 10% 15%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 35 15% 94%;
+    --muted-foreground: 30 6% 42%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 35 18% 92%;
+    --accent-foreground: 30 10% 15%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 70% 50%;
+    --destructive-foreground: 40 20% 98.5%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
+    --border: 35 12% 88%;
+    --input: 35 12% 88%;
+    --ring: 30 10% 25%;
 
-    --radius: 0.5rem;
+    --radius: 0.25rem;
 
-    --chart-1: 221.2 83.2% 53.3%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
+    --chart-1: 30 10% 25%;
+    --chart-2: 160 50% 40%;
+    --chart-3: 30 70% 50%;
+    --chart-4: 220 50% 50%;
+    --chart-5: 340 60% 50%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    /* Warm near-black background; near-white warm foreground */
+    --background: 30 8% 8%;
+    --foreground: 40 15% 95%;
 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
+    --card: 30 8% 10%;
+    --card-foreground: 40 15% 95%;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 30 8% 10%;
+    --popover-foreground: 40 15% 95%;
 
-    --primary: 217.2 91.2% 59.8%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 40 15% 95%;
+    --primary-foreground: 30 8% 8%;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 30 6% 16%;
+    --secondary-foreground: 40 15% 95%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 30 6% 16%;
+    --muted-foreground: 35 8% 65%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 30 6% 18%;
+    --accent-foreground: 40 15% 95%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 60% 45%;
+    --destructive-foreground: 40 15% 95%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
+    --border: 30 6% 20%;
+    --input: 30 6% 20%;
+    --ring: 40 15% 70%;
 
-    --chart-1: 217.2 91.2% 59.8%;
-    --chart-2: 160 60% 50%;
-    --chart-3: 30 80% 60%;
-    --chart-4: 280 65% 65%;
-    --chart-5: 340 75% 60%;
+    --chart-1: 40 15% 95%;
+    --chart-2: 160 50% 55%;
+    --chart-3: 30 70% 60%;
+    --chart-4: 220 50% 65%;
+    --chart-5: 340 60% 65%;
   }
 }
 
@@ -88,9 +91,6 @@
 }
 
 @layer utilities {
-  .text-gradient {
-    @apply bg-clip-text text-transparent bg-gradient-to-r from-primary via-blue-500 to-primary;
-  }
   .animate-fade-in {
     animation: fade-in 0.5s ease-out;
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -119,9 +119,9 @@
 }
 
 .font-display {
-  font-family: 'Newsreader', Georgia, 'Times New Roman', serif;
+  font-family: 'Plus Jakarta Sans', sans-serif;
 }
 
 .font-mono-label {
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: 'Plus Jakarta Sans', sans-serif;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -66,12 +66,12 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Newsreader:ital,wght@1,300&family=JetBrains+Mono&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&display=swap"
           rel="stylesheet"
         />
       </head>
       <body className={cn("min-h-screen bg-background font-sans antialiased")}>
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           <Navbar />
           {children}
           <Footer />

--- a/app/loan-compare/page.tsx
+++ b/app/loan-compare/page.tsx
@@ -145,7 +145,7 @@ export default function LoanComparePage() {
           <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-2">
             Tool
           </p>
-          <h1 className="font-display italic font-light text-3xl sm:text-4xl lg:text-5xl tracking-tight">
+          <h1 className="font-display font-extralight text-3xl sm:text-4xl lg:text-5xl tracking-[-0.03em]">
             Loan Comparison
           </h1>
           <p className="mt-3 text-sm sm:text-base text-muted-foreground leading-relaxed">
@@ -161,7 +161,7 @@ export default function LoanComparePage() {
                 <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
                   Inputs
                 </p>
-                <CardTitle className="font-display italic font-light text-xl tracking-tight">
+                <CardTitle className="font-display font-light text-xl tracking-tight">
                   Configure your scenario
                 </CardTitle>
               </CardHeader>
@@ -287,7 +287,7 @@ function OptionPanel({ ftype, opt, isLoading, onChange, onToggleAdvanced }: Opti
   return (
     <div className="rounded-sm border p-3 space-y-3">
       <div>
-        <p className="font-display italic font-light text-base">{ftype.label}</p>
+        <p className="font-display font-light text-base">{ftype.label}</p>
         <p className="text-[11px] text-muted-foreground mt-0.5">{ftype.rateRange}</p>
       </div>
 
@@ -432,7 +432,7 @@ function ResultCard({
           <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
             Financing
           </p>
-          <h2 className="font-display italic font-light text-lg mt-0.5">{label}</h2>
+          <h2 className="font-display font-light text-lg mt-0.5">{label}</h2>
         </div>
         <div className="flex flex-wrap gap-1.5">
           {isLowestMonthly && <WinBadge tone="monthly">Lowest /mo</WinBadge>}
@@ -513,7 +513,7 @@ function ComparisonTable({
         <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
           Full Breakdown
         </p>
-        <CardTitle className="font-display italic font-light text-xl tracking-tight mt-0.5">
+        <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
           Side-by-Side Comparison
         </CardTitle>
         <p className="text-[11px] text-muted-foreground">
@@ -586,7 +586,7 @@ function Stat({
       <p className="font-mono-label text-[10px] uppercase tracking-[0.18em] text-muted-foreground opacity-60">{label}</p>
       <p
         className={cn(
-          "mt-1.5 font-display italic font-light text-2xl tabular-nums tracking-tight",
+          "mt-1.5 font-display font-light text-2xl tabular-nums tracking-tight",
           accent === "warning" && "text-orange-600 dark:text-orange-400"
         )}
       >
@@ -616,7 +616,7 @@ function EmptyState() {
       <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-3">
         No comparison yet
       </p>
-      <h2 className="font-display italic font-light text-xl sm:text-2xl mb-2">
+      <h2 className="font-display font-light text-xl sm:text-2xl mb-2">
         Configure your options and compare
       </h2>
       <p className="text-sm text-muted-foreground max-w-md mx-auto leading-relaxed">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -8,7 +8,7 @@ export default function NotFound() {
   return (
     <div className="flex min-h-[60vh] items-center justify-center px-4">
       <div className="max-w-sm text-center space-y-4">
-        <h1 className="font-display italic font-light text-3xl">Not Found</h1>
+        <h1 className="font-display font-light text-3xl">Not Found</h1>
         <p className="text-sm text-muted-foreground">Could not find the requested page.</p>
         <button
           onClick={() => router.push("/")}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -84,7 +84,7 @@ export default function LandingPage() {
         <p className="font-mono-label text-[10px] uppercase tracking-[0.3em] text-muted-foreground opacity-60 mb-4">
           Philippine Personal Finance
         </p>
-        <h1 className="font-display italic font-light text-5xl sm:text-7xl lg:text-8xl leading-[0.95] tracking-tight">
+        <h1 className="font-display font-extralight text-5xl sm:text-7xl lg:text-8xl leading-[0.95] tracking-[-0.04em]">
           Savvy Spender
         </h1>
         <p className="mt-6 text-muted-foreground max-w-md leading-relaxed">
@@ -176,7 +176,7 @@ function ToolCard({ tool, delay }: { tool: Tool; delay: number }) {
           </span>
         )}
       </div>
-      <h3 className="font-display italic font-light text-xl tracking-tight leading-tight">{tool.title}</h3>
+      <h3 className="font-display font-light text-xl tracking-tight leading-tight">{tool.title}</h3>
       <p className="mt-2 text-[12px] text-muted-foreground leading-relaxed">{tool.desc}</p>
       {isLive && (
         <div className="mt-4 flex items-center justify-between">

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -10,7 +10,7 @@ const Footer: React.FC = () => {
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 text-sm">
           {/* About */}
           <div>
-            <h3 className="font-display italic font-light text-lg mb-3">Savvy Spender</h3>
+            <h3 className="font-display font-light text-lg mb-3">Savvy Spender</h3>
             <p className="text-muted-foreground text-xs leading-relaxed">
               A focused installment calculator built for Filipino consumers. More tools coming soon.
             </p>

--- a/components/installment/amortization-schedule.tsx
+++ b/components/installment/amortization-schedule.tsx
@@ -68,7 +68,7 @@ const AmortizationSchedule: React.FC<AmortizationScheduleProps> = ({ selected, p
             <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
               Schedule
             </p>
-            <CardTitle className="font-display italic font-light text-xl tracking-tight mt-0.5">
+            <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
               Month-by-Month
             </CardTitle>
             <CardDescription className="text-[12px] mt-1">

--- a/components/installment/card-form.tsx
+++ b/components/installment/card-form.tsx
@@ -127,7 +127,7 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit, isL
           <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
             Inputs
           </p>
-          <CardTitle className="font-display italic font-light text-xl tracking-tight">
+          <CardTitle className="font-display font-light text-xl tracking-tight">
             Configure your scenario
           </CardTitle>
         </CardHeader>

--- a/components/installment/cost-breakdown.tsx
+++ b/components/installment/cost-breakdown.tsx
@@ -32,7 +32,7 @@ const CostBreakdown: React.FC<CostBreakdownProps> = ({ calculatedData, amount })
         <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
           Where it goes
         </p>
-        <CardTitle className="font-display italic font-light text-xl tracking-tight mt-0.5">
+        <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
           Cost Breakdown
         </CardTitle>
         <CardDescription className="text-[12px]">
@@ -103,7 +103,7 @@ const CostBreakdown: React.FC<CostBreakdownProps> = ({ calculatedData, amount })
               <p className="font-mono-label text-[10px] uppercase tracking-[0.2em] text-muted-foreground opacity-60">
                 You receive
               </p>
-              <p className="font-display italic font-light text-2xl tabular-nums">
+              <p className="font-display font-light text-2xl tabular-nums">
                 {formatCurrency(calculatedData.netProceeds)}
               </p>
             </div>

--- a/components/installment/other-plan-table.tsx
+++ b/components/installment/other-plan-table.tsx
@@ -73,7 +73,7 @@ const OtherPlanTable: React.FC<OtherPlanTableProps> = ({ calculatedData, budget 
     return (
       <Card className="border-border">
         <CardHeader>
-          <CardTitle className="font-display italic font-light text-xl tracking-tight">Compare Terms</CardTitle>
+          <CardTitle className="font-display font-light text-xl tracking-tight">Compare Terms</CardTitle>
           <CardDescription>All installment terms side by side.</CardDescription>
         </CardHeader>
         <CardContent>
@@ -98,7 +98,7 @@ const OtherPlanTable: React.FC<OtherPlanTableProps> = ({ calculatedData, budget 
             <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
               Comparison
             </p>
-            <CardTitle className="font-display italic font-light text-xl tracking-tight mt-0.5">
+            <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
               All Terms Side by Side
             </CardTitle>
           </div>

--- a/components/installment/selected-plan.tsx
+++ b/components/installment/selected-plan.tsx
@@ -28,7 +28,7 @@ const StatBlock: React.FC<{
     </p>
     <p
       className={cn(
-        "mt-1.5 font-display italic font-light tabular-nums tracking-tight leading-none",
+        "mt-1.5 font-display font-light tabular-nums tracking-tight leading-none",
         size === "lg" ? "text-3xl sm:text-4xl" : "text-2xl sm:text-3xl",
         accent === "primary" && "text-foreground",
         accent === "warning" && "text-orange-600 dark:text-orange-400",
@@ -95,7 +95,7 @@ const CardSelectedPlan: React.FC<CardSelectedPlanProps> = ({ calculatedData, pay
             Selected Plan
           </p>
           <p className="text-sm mt-0.5">
-            <span className="font-display italic font-light text-lg tabular-nums">{selected.months}</span>{" "}
+            <span className="font-display font-light text-lg tabular-nums">{selected.months}</span>{" "}
             <span className="text-muted-foreground">months</span>
             <span className="mx-2 text-muted-foreground/40">·</span>
             <span className="tabular-nums">{formatPercent(selected.simpleInterest)}</span>{" "}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -34,7 +34,7 @@ const Navbar: React.FC = () => {
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
         <Link href="/" className="flex items-center gap-2">
           <Image src="/android-chrome-512x512.png" alt="Savvy Spender" width={28} height={28} />
-          <span className="font-display italic font-light text-lg hidden sm:inline">Savvy Spender</span>
+          <span className="font-display font-light text-lg hidden sm:inline">Savvy Spender</span>
         </Link>
 
         {/* Desktop navigation */}
@@ -90,7 +90,7 @@ const Navbar: React.FC = () => {
               </SheetTrigger>
               <SheetContent>
                 <SheetHeader>
-                  <SheetTitle className="font-display italic font-light text-xl">Navigate</SheetTitle>
+                  <SheetTitle className="font-display font-light text-xl">Navigate</SheetTitle>
                   <SheetDescription>
                     Calculator, banks, and documentation.
                   </SheetDescription>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -35,7 +35,7 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h3
     ref={ref}
-    className={cn("font-display italic font-light text-xl leading-tight tracking-tight", className)}
+    className={cn("font-display font-light text-xl leading-tight tracking-tight", className)}
     {...props}
   />
 ))

--- a/constant/fx-data.ts
+++ b/constant/fx-data.ts
@@ -24,6 +24,8 @@ export interface CardFxEntry {
  * card reviews. Last reviewed: 2026. Rates may change — always verify with your
  * card issuer before travelling.
  */
+export const CARD_FX_DATA_REVIEWED = "May 2026";
+
 export const CARD_FX_DATA: CardFxEntry[] = [
   // ── BDO Unibank ──────────────────────────────────────────────────
   {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,9 @@ const config = {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ["Plus Jakarta Sans", "sans-serif"],
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
- Replace Newsreader + JetBrains Mono with Plus Jakarta Sans across the whole app
  (layout.tsx Google Fonts link, globals.css font-display/font-mono-label, tailwind.config.ts font-sans)
- Set ThemeProvider defaultTheme from "system" to "light"
- Rewrite /docs page to cover only the 3 current live tools (Installment Calculator,
  Card FX Comparison, Loan Comparison); remove all 17+ sections for removed tools
- Fix in-house dealer rate in /bank-conversion-list Car Loans table: 1.0–2.0% → 1.5–2.5%
- Add SourceNote component to /bank-conversion-list; attach source attribution and
  "As of 2026" date to every table section (credit card, personal loans, SSS, Pag-IBIG,
  car loans, housing loans, 0% installment)
- Export CARD_FX_DATA_REVIEWED constant from constant/fx-data.ts
- Show bank markup last-reviewed date in /fx-compare sidebar disclaimer

https://claude.ai/code/session_01EUuE39gED6k9xrnguhRkyV