### PR TITLE
Add Rent vs. Buy a Home simulator tool

### DIFF
--- a/app/_components/copy-link-button.tsx
+++ b/app/_components/copy-link-button.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Link2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+/** Copies the current URL (which encodes the tool's state) to the clipboard. */
+export const CopyLinkButton: React.FC = () => {
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      toast.success("Link copied", { description: "Anyone who opens it sees this exact scenario." });
+    } catch {
+      toast.error("Couldn't copy — your browser blocked clipboard access.");
+    }
+  };
+  return (
+    <Button variant="outline" size="sm" onClick={copy} className="gap-1.5">
+      <Link2 className="h-3.5 w-3.5" />
+      Copy link
+    </Button>
+  );
+};

--- a/app/_components/glossary.tsx
+++ b/app/_components/glossary.tsx
@@ -1,0 +1,32 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export interface GlossaryItem {
+  term: string;
+  def: React.ReactNode;
+}
+
+/** Definition list of the jargon a tool uses. Two columns from md up. */
+export const Glossary: React.FC<{ items: GlossaryItem[]; title?: string }> = ({
+  items,
+  title = "Glossary",
+}) => (
+  <Card className="border-border">
+    <CardHeader className="pb-2">
+      <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+        {title}
+      </p>
+    </CardHeader>
+    <CardContent>
+      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3">
+        {items.map((item) => (
+          <div key={item.term}>
+            <dt className="font-mono-label text-[10px] uppercase tracking-[0.16em] text-foreground mb-0.5">
+              {item.term}
+            </dt>
+            <dd className="text-[12px] text-muted-foreground leading-relaxed">{item.def}</dd>
+          </div>
+        ))}
+      </dl>
+    </CardContent>
+  </Card>
+);

--- a/app/_components/how-it-works.tsx
+++ b/app/_components/how-it-works.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export interface HowItWorksPoint {
+  heading?: string;
+  body: React.ReactNode;
+}
+
+interface HowItWorksProps {
+  points: HowItWorksPoint[];
+  docsHref?: string; // optional "Full method →" deep link into /docs
+}
+
+/** Plain-language "what this does / what the result means" card. */
+export const HowItWorks: React.FC<HowItWorksProps> = ({ points, docsHref }) => (
+  <Card className="border-border">
+    <CardHeader className="pb-2">
+      <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+        How it works
+      </p>
+    </CardHeader>
+    <CardContent className="space-y-2.5 text-[12px] text-muted-foreground leading-relaxed">
+      {points.map((point, i) => (
+        <p key={i}>
+          {point.heading && <span className="text-foreground font-medium">{point.heading}. </span>}
+          {point.body}
+        </p>
+      ))}
+      {docsHref && (
+        <Link
+          href={docsHref}
+          className="inline-block pt-1 text-[12px] font-medium text-foreground underline underline-offset-4"
+        >
+          Full method →
+        </Link>
+      )}
+    </CardContent>
+  </Card>
+);

--- a/app/_components/tool-header.tsx
+++ b/app/_components/tool-header.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+interface ToolHeaderProps {
+  title: string;
+  description: React.ReactNode;
+}
+
+/** Standard tool page header: an "← All tools" breadcrumb, the h1, and intro. */
+export const ToolHeader: React.FC<ToolHeaderProps> = ({ title, description }) => (
+  <div className="mb-8 max-w-3xl">
+    <Link
+      href="/"
+      className="inline-flex items-center gap-1 font-mono-label text-[10px] uppercase tracking-[0.2em] text-muted-foreground opacity-60 hover:opacity-100 transition-opacity mb-3"
+    >
+      <ArrowLeft className="h-3 w-3" />
+      All tools
+    </Link>
+    <h1 className="font-display font-extralight text-3xl sm:text-4xl lg:text-5xl tracking-[-0.03em]">
+      {title}
+    </h1>
+    <p className="mt-3 text-sm sm:text-base text-muted-foreground leading-relaxed">{description}</p>
+  </div>
+);

--- a/app/_lib/seo.ts
+++ b/app/_lib/seo.ts
@@ -1,0 +1,71 @@
+import type { Metadata } from "next";
+
+/** Canonical site origin (matches the root metadataBase). */
+export const SITE_URL = "https://www.savvyspender.info";
+
+interface ToolMetaInput {
+  title: string;
+  description: string;
+  path: string; // e.g. "/calculator"
+  keywords: string[];
+}
+
+/**
+ * Per-tool Metadata. The root layout supplies the "%s | Savvy Spender" title
+ * template, so `title` here is the bare tool name; canonical + social tags are
+ * filled from the path. Images are intentionally omitted (no OG art yet).
+ */
+export function buildToolMetadata({ title, description, path, keywords }: ToolMetaInput): Metadata {
+  const url = `${SITE_URL}${path}`;
+  const social = `${title} | Savvy Spender`;
+  return {
+    title,
+    description,
+    keywords,
+    alternates: { canonical: url },
+    openGraph: { type: "website", url, title: social, description },
+    twitter: { card: "summary", site: SITE_URL, title: social, description },
+  };
+}
+
+/** Schema.org WebApplication — the whole free finance toolkit. */
+export function webApplicationLd(): object {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    name: "Savvy Spender",
+    url: SITE_URL,
+    applicationCategory: "FinanceApplication",
+    operatingSystem: "Web",
+    description:
+      "Free, open-source Philippine financial tools — compare installment plans, credit-card forex, car financing, freelancer payouts, and rent vs. buy.",
+    offers: { "@type": "Offer", price: "0", priceCurrency: "PHP" },
+  };
+}
+
+/** Schema.org FAQPage from question/answer pairs (rich-snippet eligible). */
+export function faqPageLd(items: { q: string; a: string }[]): object {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: items.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: { "@type": "Answer", text: item.a },
+    })),
+  };
+}
+
+/** Schema.org BreadcrumbList: Home › <tool>. */
+export function breadcrumbLd(items: { name: string; path: string }[]): object {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      item: `${SITE_URL}${item.path}`,
+    })),
+  };
+}

--- a/app/_lib/tools.ts
+++ b/app/_lib/tools.ts
@@ -3,6 +3,7 @@ import {
   Building2,
   Calculator,
   Globe,
+  Home,
   PiggyBank,
   Scale,
   TrendingUp,
@@ -61,6 +62,14 @@ export const TOOLS: Tool[] = [
     href: "/payout-compare",
     desc: "Getting paid from abroad? See which app nets you the most pesos after fees and FX — Wise, Payoneer, PayPal, e-wallets, banks, and crypto.",
     meta: "8 platforms · live FX · net PHP simulator",
+  },
+  {
+    status: "live",
+    icon: Home,
+    title: "Rent vs. Buy a Home",
+    href: "/rent-vs-buy",
+    desc: "Buy the condo or keep renting and invest the difference? A year-by-year wealth simulation with the break-even year and the odds buying actually wins.",
+    meta: "break-even year · invest-the-difference · Monte-Carlo odds",
   },
   {
     status: "soon",

--- a/app/bank-conversion-list/_components/credit-card-section.tsx
+++ b/app/bank-conversion-list/_components/credit-card-section.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import {
   Body,
   DataTable,
@@ -7,6 +8,15 @@ import {
   SectionTitle,
   SourceNote,
 } from "./section-primitives";
+
+const CalcCta: React.FC<{ href: string; children: React.ReactNode }> = ({ href, children }) => (
+  <Link
+    href={href}
+    className="inline-block mt-1 text-[12px] font-medium text-foreground underline underline-offset-4"
+  >
+    {children}
+  </Link>
+);
 
 export function CreditCardSection() {
   return (
@@ -34,6 +44,9 @@ export function CreditCardSection() {
           ]}
         />
         <Body>Promo rates (as low as 0.49%) are typically invite-only or limited-time.</Body>
+        <CalcCta href="/calculator?type=balance-conversion&rate=0.99">
+          Compute a balance conversion in the calculator →
+        </CalcCta>
         <SourceNote>
           Sources: BSP Circular No. 1098 (2020), No. 1165 (2023), and bank-published fee schedules.
           As of 2026.
@@ -59,6 +72,9 @@ export function CreditCardSection() {
           ]}
         />
         <Body>Processing fees typically range from ₱250–₱500 per availment.</Body>
+        <CalcCta href="/calculator?type=credit-to-cash&rate=0.99&fee=300">
+          Compute a credit-to-cash plan in the calculator →
+        </CalcCta>
         <SourceNote>
           Sources: Bank-published fee schedules and cardholder agreements. As of 2026.
         </SourceNote>

--- a/app/bank-conversion-list/_components/personal-loans-section.tsx
+++ b/app/bank-conversion-list/_components/personal-loans-section.tsx
@@ -1,6 +1,8 @@
+import Link from "next/link";
 import {
   Body,
   DataTable,
+  Divider,
   DocSection,
   SectionLabel,
   SectionTitle,
@@ -9,27 +11,61 @@ import {
 
 export function PersonalLoansSection() {
   return (
-    <DocSection>
-      <SectionLabel>Loans</SectionLabel>
-      <SectionTitle>Personal Loans (Unsecured)</SectionTitle>
-      <Body>
-        Standalone bank loans, separate from credit cards. Subject to Documentary Stamp Tax (DST)
-        on loan amounts above ₱250,000 (~0.75% of the loan face value, deducted from proceeds).
-      </Body>
-      <DataTable
-        headers={["Bank", "Monthly Rate", "Approx. EIR (p.a.)", "Terms", "Processing Fee", "Max Loan"]}
-        rows={[
-          ["BDO", "1.39%–1.79%", "18%–24%", "6–36 months", "₱1,300", "₱3M"],
-          ["BPI", "~1.20%", "25%–29%", "12–36 months", "₱1,500", "₱3M"],
-          ["Metrobank", "~1.25%", "30%–33%", "12–36 months", "₱1,500", "₱2M"],
-          ["UnionBank", "Personalized", "Varies", "Varies", "Varies", "₱2M"],
-          ["Security Bank", "Personalized", "Varies", "12–36 months", "Varies", "₱2M"],
-          ["Tonik", "~1.79%–3.46%", "Varies", "6–24 months", "None", "₱250K"],
-        ]}
-      />
-      <SourceNote>
-        Sources: Bank-published rate tables and BSP Circular No. 1098. As of 2026.
-      </SourceNote>
-    </DocSection>
+    <>
+      <DocSection>
+        <SectionLabel>Loans</SectionLabel>
+        <SectionTitle>Personal Loans (Unsecured)</SectionTitle>
+        <Body>
+          Standalone bank loans, separate from credit cards. Subject to Documentary Stamp Tax (DST)
+          on loan amounts above ₱250,000 (~0.75% of the loan face value, deducted from proceeds).
+        </Body>
+        <DataTable
+          headers={["Bank", "Monthly Rate", "Approx. EIR (p.a.)", "Terms", "Processing Fee", "Max Loan"]}
+          rows={[
+            ["BDO", "1.39%–1.79%", "18%–24%", "6–36 months", "₱1,300", "₱3M"],
+            ["BPI", "~1.20%", "25%–29%", "12–36 months", "₱1,500", "₱3M"],
+            ["Metrobank", "~1.25%", "30%–33%", "12–36 months", "₱1,500", "₱2M"],
+            ["UnionBank", "Personalized", "Varies", "Varies", "Varies", "₱2M"],
+            ["Security Bank", "Personalized", "Varies", "12–36 months", "Varies", "₱2M"],
+            ["RCBC", "~1.30%", "26%–30%", "12–36 months", "₱1,500", "₱1M"],
+            ["PSBank", "~1.75%", "Varies", "12–36 months", "₱1,500", "₱2M"],
+          ]}
+        />
+        <Link
+          href="/calculator?type=personal-loan&rate=1.25&fee=1500&term=24"
+          className="inline-block mt-1 text-[12px] font-medium text-foreground underline underline-offset-4"
+        >
+          Compute a personal loan in the calculator →
+        </Link>
+        <SourceNote>
+          Sources: Bank-published rate tables and BSP Circular No. 1098. As of 2026.
+        </SourceNote>
+      </DocSection>
+
+      <Divider />
+
+      <DocSection>
+        <SectionLabel>Loans</SectionLabel>
+        <SectionTitle>Digital Banks &amp; E-Wallet Loans</SectionTitle>
+        <Body>
+          Fast, small-ticket loans from digital banks and e-wallets — minimal paperwork, instant
+          disbursement. Monthly rates typically run ~1.58%–2.83% (EIR ~19%–34%). Rates are
+          personalized from your in-app credit score, so treat these as indicative.
+        </Body>
+        <DataTable
+          headers={["Lender", "Monthly Rate", "Terms", "Fee", "Max Loan"]}
+          rows={[
+            ["GCash GLoan", "from ~1.59%", "3–12 months", "Disbursement fee", "₱150K"],
+            ["Maya (Personal Loan)", "~1.5%–3%", "Varies", "Varies", "₱250K"],
+            ["Tonik", "~1.79%–3.46%", "6–24 months", "None", "₱250K"],
+            ["UnionDigital", "Personalized", "Varies", "Varies", "Varies"],
+            ["GoTyme / UNO / UnionBank Digital", "Personalized", "Varies", "Varies", "Varies"],
+          ]}
+        />
+        <SourceNote>
+          Sources: GCash Help Center, Maya, Tonik, and BitPinas digital-bank roundups. As of 2026.
+        </SourceNote>
+      </DocSection>
+    </>
   );
 }

--- a/app/calculator/_components/amortization-schedule.tsx
+++ b/app/calculator/_components/amortization-schedule.tsx
@@ -5,8 +5,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { formatCurrency } from "@/lib/client";
+import { downloadCsv } from "@/lib/csv";
 import { InstallmentOption } from "../_lib/types";
-import { ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons";
+import { ChevronDownIcon, ChevronUpIcon, DownloadIcon } from "@radix-ui/react-icons";
 import { cn } from "@/lib/utils";
 
 interface AmortizationScheduleProps {
@@ -53,6 +54,21 @@ const AmortizationSchedule: React.FC<AmortizationScheduleProps> = ({ selected, p
     return rows;
   }, [selected, principal, monthlyRate]);
 
+  const exportCsv = () => {
+    downloadCsv(
+      `amortization-${selected?.months ?? 0}mo`,
+      ["Month", "Payment", "Principal", "Interest", "Balance", "Total Paid"],
+      schedule.map((r) => [
+        r.month,
+        r.payment.toFixed(2),
+        r.principalPortion.toFixed(2),
+        r.interestPortion.toFixed(2),
+        r.remainingBalance.toFixed(2),
+        r.totalPaidSoFar.toFixed(2),
+      ])
+    );
+  };
+
   if (!selected || schedule.length === 0) return null;
 
   return (
@@ -76,9 +92,24 @@ const AmortizationSchedule: React.FC<AmortizationScheduleProps> = ({ selected, p
               month{+selected.months === 1 ? "" : "s"} · constant payments via add-on (flat) rate.
             </CardDescription>
           </div>
-          <Button variant="ghost" size="icon" aria-label={isExpanded ? "Collapse schedule" : "Expand schedule"}>
-            {isExpanded ? <ChevronUpIcon className="h-4 w-4" /> : <ChevronDownIcon className="h-4 w-4" />}
-          </Button>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5 font-mono-label text-[10px] uppercase tracking-[0.12em]"
+              aria-label="Download schedule as CSV"
+              onClick={(e) => {
+                e.stopPropagation();
+                exportCsv();
+              }}
+            >
+              <DownloadIcon className="h-3.5 w-3.5" />
+              CSV
+            </Button>
+            <Button variant="ghost" size="icon" aria-label={isExpanded ? "Collapse schedule" : "Expand schedule"}>
+              {isExpanded ? <ChevronUpIcon className="h-4 w-4" /> : <ChevronDownIcon className="h-4 w-4" />}
+            </Button>
+          </div>
         </div>
       </CardHeader>
 

--- a/app/calculator/_components/card-form.tsx
+++ b/app/calculator/_components/card-form.tsx
@@ -19,9 +19,20 @@ import type { CalculatorType } from "../_lib/config";
 const PRESET_TERMS = ["3", "6", "9", "12", "18", "24", "36"];
 const PERSONAL_LOAN_TERMS = ["6", "12", "18", "24", "30", "36"];
 
+const BASE_DEFAULTS: CalculateForm = {
+  calculatorType: "balance-conversion",
+  amount: 10000,
+  interestRate: 0.99,
+  numInstallments: "3",
+  processingFee: 0,
+  installmentAmount: 0,
+  monthlyBudget: 0,
+};
+
 interface CardInstallmentFormProps {
   onSubmit: (values: CalculateForm) => void;
   isLoading?: boolean;
+  initialValues?: Partial<CalculateForm>;
 }
 
 const InfoTip: React.FC<{ content: string }> = ({ content }) => (
@@ -35,21 +46,22 @@ const InfoTip: React.FC<{ content: string }> = ({ content }) => (
   </Tooltip>
 );
 
-const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit, isLoading = false }) => {
+const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({
+  onSubmit,
+  isLoading = false,
+  initialValues,
+}) => {
   const form = useForm<CalculateForm>({
     resolver: zodResolver(CalculateFormSchema),
-    defaultValues: {
-      calculatorType: "balance-conversion",
-      amount: 10000,
-      interestRate: 0.99,
-      numInstallments: "3",
-      processingFee: 0,
-      installmentAmount: 0,
-      monthlyBudget: 0,
-    },
+    defaultValues: { ...BASE_DEFAULTS, ...initialValues },
   });
 
-  const [selectedTerms, setSelectedTerms] = useState<string[]>(["3", "6", "9", "12", "18", "24", "36"]);
+  const initialTerm = initialValues?.numInstallments;
+  const [selectedTerms, setSelectedTerms] = useState<string[]>(() =>
+    initialTerm && !PRESET_TERMS.includes(initialTerm)
+      ? [...PRESET_TERMS, initialTerm].sort((a, b) => +a - +b)
+      : PRESET_TERMS
+  );
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   const calculatorType = form.watch("calculatorType") as CalculatorType;
@@ -98,15 +110,7 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({ onSubmit, isL
   };
 
   const handleReset = () => {
-    form.reset({
-      calculatorType: "balance-conversion",
-      amount: 10000,
-      interestRate: 0.99,
-      numInstallments: "3",
-      processingFee: 0,
-      installmentAmount: 0,
-      monthlyBudget: 0,
-    });
+    form.reset(BASE_DEFAULTS);
     setSelectedTerms(PRESET_TERMS);
     setShowAdvanced(false);
   };

--- a/app/calculator/_components/card-form.tsx
+++ b/app/calculator/_components/card-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "@/components/ui/input";
@@ -56,11 +56,13 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({
     defaultValues: { ...BASE_DEFAULTS, ...initialValues },
   });
 
+  const initialType = (initialValues?.calculatorType ?? "balance-conversion") as CalculatorType;
+  const initialPresets = initialType === "personal-loan" ? PERSONAL_LOAN_TERMS : PRESET_TERMS;
   const initialTerm = initialValues?.numInstallments;
   const [selectedTerms, setSelectedTerms] = useState<string[]>(() =>
-    initialTerm && !PRESET_TERMS.includes(initialTerm)
-      ? [...PRESET_TERMS, initialTerm].sort((a, b) => +a - +b)
-      : PRESET_TERMS
+    initialTerm && !initialPresets.includes(initialTerm)
+      ? [...initialPresets, initialTerm].sort((a, b) => +a - +b)
+      : initialPresets
   );
   const [showAdvanced, setShowAdvanced] = useState(false);
 
@@ -87,8 +89,14 @@ const CardInstallmentForm: React.FC<CardInstallmentFormProps> = ({
     return amount - estimatedDST - processingFee;
   }, [calculatorType, amount, estimatedDST, processingFee]);
 
-  // Reset selected terms when calc type changes; keep current selection in sync
+  // Reset selected terms when calc type changes; keep current selection in sync.
+  // Skips the initial mount so a deep-link-prefilled term/selection isn't wiped.
+  const didMountTerms = useRef(false);
   useEffect(() => {
+    if (!didMountTerms.current) {
+      didMountTerms.current = true;
+      return;
+    }
     setSelectedTerms(availablePresets);
     if (!availablePresets.includes(form.getValues("numInstallments"))) {
       form.setValue("numInstallments", availablePresets[0]);

--- a/app/calculator/layout.tsx
+++ b/app/calculator/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { JsonLd } from "@/components/json-ld";
+import { breadcrumbLd, buildToolMetadata } from "@/app/_lib/seo";
+
+export const metadata: Metadata = buildToolMetadata({
+  title: "Installment Calculator",
+  description:
+    "Compare credit-card balance conversion, credit-to-cash, and personal loan installment plans across terms. See the monthly payment, effective interest rate (EIR), and full amortization schedule.",
+  path: "/calculator",
+  keywords: [
+    "installment calculator philippines",
+    "balance conversion calculator",
+    "credit to cash calculator",
+    "monthly amortization",
+    "effective interest rate calculator",
+    "credit card installment philippines",
+  ],
+});
+
+export default function CalculatorLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <JsonLd
+        data={breadcrumbLd([
+          { name: "Home", path: "/" },
+          { name: "Installment Calculator", path: "/calculator" },
+        ])}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/calculator/page.tsx
+++ b/app/calculator/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { Suspense, useState, useCallback, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 import CardInstallmentForm from "./_components/card-form";
@@ -22,7 +23,20 @@ const CALC_GLOSSARY = [
   { term: "DST", def: "Documentary stamp tax (₱1.50 per ₱200) applied to personal loans above ₱250,000." },
 ];
 
-export default function CalculatorPage() {
+const CALC_DEFAULTS: CalculateForm = {
+  calculatorType: "balance-conversion",
+  amount: 10000,
+  interestRate: 0.99,
+  numInstallments: "3",
+  processingFee: 0,
+  installmentAmount: 0,
+  monthlyBudget: 0,
+};
+
+const VALID_TYPES = ["balance-conversion", "credit-to-cash", "personal-loan"];
+
+function Calculator() {
+  const searchParams = useSearchParams();
   const [calculatedData, setCalculatedData] = useState<AllInstallmentOption>();
   const [paymentDifferences, setPaymentDifferences] = useState<PaymentDifferences>();
   const [hasCalculated, setHasCalculated] = useState(false);
@@ -75,6 +89,30 @@ export default function CalculatorPage() {
     calculateInstallmentData(values);
   };
 
+  // Prefill (and auto-calculate) from URL params — used by shareable links and
+  // the Bank list's "open in calculator" deep-links.
+  const initialValues: Partial<CalculateForm> = {};
+  const t = searchParams.get("type");
+  const a = searchParams.get("amt");
+  const r = searchParams.get("rate");
+  const f = searchParams.get("fee");
+  const n = searchParams.get("term");
+  if (t && VALID_TYPES.includes(t)) initialValues.calculatorType = t as CalculatorType;
+  if (a && Number.isFinite(+a)) initialValues.amount = +a;
+  if (r && Number.isFinite(+r)) initialValues.interestRate = +r;
+  if (f && Number.isFinite(+f)) initialValues.processingFee = +f;
+  if (n && Number.isFinite(+n)) initialValues.numInstallments = n;
+  const hasParams = Object.keys(initialValues).length > 0;
+
+  const didAutoRun = useRef(false);
+  useEffect(() => {
+    if (didAutoRun.current || !hasParams) return;
+    didAutoRun.current = true;
+    calculateInstallmentData({ ...CALC_DEFAULTS, ...initialValues });
+    // Run once on mount when deep-linked.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <main className="max-w-7xl mx-auto px-4 py-6 sm:py-8">
       <ToolHeader
@@ -85,7 +123,11 @@ export default function CalculatorPage() {
       <div className="grid lg:grid-cols-[380px_1fr] gap-6 lg:gap-10">
         {/* Form column — sticky on desktop */}
         <aside className="lg:sticky lg:top-20 lg:self-start lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto lg:pr-2 -mr-2">
-          <CardInstallmentForm onSubmit={onSubmit} isLoading={isLoading} />
+          <CardInstallmentForm
+            onSubmit={onSubmit}
+            isLoading={isLoading}
+            initialValues={hasParams ? initialValues : undefined}
+          />
         </aside>
 
         {/* Results column */}
@@ -145,5 +187,13 @@ function EmptyState() {
         effective interest, and the full amortization schedule.
       </p>
     </div>
+  );
+}
+
+export default function CalculatorPage() {
+  return (
+    <Suspense fallback={<div className="max-w-7xl mx-auto px-4 py-10 text-sm text-muted-foreground">Loading…</div>}>
+      <Calculator />
+    </Suspense>
   );
 }

--- a/app/calculator/page.tsx
+++ b/app/calculator/page.tsx
@@ -11,6 +11,16 @@ import AmortizationSchedule from "./_components/amortization-schedule";
 import { CALCULATOR_CONFIG, type CalculatorType } from "./_lib/config";
 import type { AllInstallmentOption, PaymentDifferences } from "./_lib/types";
 import type { CalculateForm } from "./_lib/schema";
+import { ToolHeader } from "@/app/_components/tool-header";
+import { HowItWorks } from "@/app/_components/how-it-works";
+import { Glossary } from "@/app/_components/glossary";
+
+const CALC_GLOSSARY = [
+  { term: "Add-on rate", def: "A flat monthly % charged on the original principal, not the declining balance — common for PH installments." },
+  { term: "EIR / EIRPA", def: "Effective interest rate per annum — the real annualized cost, so plans with different terms compare fairly." },
+  { term: "Factor rate", def: "The multiplier that turns the principal into total repayment over the term." },
+  { term: "DST", def: "Documentary stamp tax (₱1.50 per ₱200) applied to personal loans above ₱250,000." },
+];
 
 export default function CalculatorPage() {
   const [calculatedData, setCalculatedData] = useState<AllInstallmentOption>();
@@ -67,18 +77,10 @@ export default function CalculatorPage() {
 
   return (
     <main className="max-w-7xl mx-auto px-4 py-6 sm:py-8">
-      {/* Page Header */}
-      <div className="mb-8 max-w-3xl">
-        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-2">
-          Tool
-        </p>
-        <h1 className="font-display font-extralight text-3xl sm:text-4xl lg:text-5xl tracking-[-0.03em]">
-          Installment Calculator
-        </h1>
-        <p className="mt-3 text-sm sm:text-base text-muted-foreground leading-relaxed">
-          Compare balance conversion, credit-to-cash, and personal loan installment plans across multiple terms.
-        </p>
-      </div>
+      <ToolHeader
+        title="Installment Calculator"
+        description="Compare balance conversion, credit-to-cash, and personal loan installment plans across multiple terms — with monthly payments, effective interest, and a full amortization schedule."
+      />
 
       <div className="grid lg:grid-cols-[380px_1fr] gap-6 lg:gap-10">
         {/* Form column — sticky on desktop */}
@@ -114,6 +116,15 @@ export default function CalculatorPage() {
               )}
             </>
           )}
+
+          <HowItWorks
+            docsHref="/docs"
+            points={[
+              { heading: "What it does", body: "Turns a lump sum into fixed monthly installments across terms and shows the true cost of each." },
+              { heading: "Reading it", body: "The lowest monthly payment isn't always the cheapest — check total interest and the effective interest rate (EIR), which annualizes the real cost." },
+            ]}
+          />
+          <Glossary items={CALC_GLOSSARY} />
         </section>
       </div>
     </main>

--- a/app/docs/_components/rent-vs-buy-section.tsx
+++ b/app/docs/_components/rent-vs-buy-section.tsx
@@ -1,6 +1,6 @@
 import { Body, Divider, DocSection, Formula, Note, SectionLabel, SectionTitle } from "./doc-primitives";
 
-export function RentVsBuySection() {
+export const RentVsBuySection: React.FC = () => {
   return (
     <>
       <DocSection>
@@ -65,4 +65,4 @@ export function RentVsBuySection() {
       </DocSection>
     </>
   );
-}
+};

--- a/app/docs/_components/rent-vs-buy-section.tsx
+++ b/app/docs/_components/rent-vs-buy-section.tsx
@@ -1,0 +1,68 @@
+import { Body, Divider, DocSection, Formula, Note, SectionLabel, SectionTitle } from "./doc-primitives";
+
+export function RentVsBuySection() {
+  return (
+    <>
+      <DocSection>
+        <SectionLabel>Rent vs. Buy a Home</SectionLabel>
+        <SectionTitle>The Invest-the-Difference Model</SectionTitle>
+        <Body>
+          Comparing a monthly mortgage to monthly rent is misleading — it ignores the down payment
+          you tie up, the equity you build, and the returns you forgo by not investing that cash.
+          This tool runs a year-by-year wealth simulation where both paths start with the same money.
+          The buyer sinks it into the down payment and closing costs; the renter keeps it invested.
+          Each year, whichever path costs less invests the surplus, so the two are compared on equal
+          footing.
+        </Body>
+        <Formula>
+          <div>Buy net worth = property value − loan balance − selling costs + invested surplus</div>
+          <div>Rent net worth = invested cash (down payment + closing) + invested surplus</div>
+          <div>Break-even year = first year Buy net worth ≥ Rent net worth</div>
+        </Formula>
+      </DocSection>
+
+      <Divider />
+
+      <DocSection>
+        <SectionLabel>Rent vs. Buy a Home</SectionLabel>
+        <SectionTitle>Costs of Owning</SectionTitle>
+        <Body>
+          The mortgage is a standard amortising annuity. On top of it, ownership carries recurring
+          costs the simulation escalates each year:
+        </Body>
+        <Formula>
+          <div>Monthly mortgage = P·i / (1 − (1 + i)⁻ⁿ), i = annual rate / 12</div>
+          <div>Amilyar (RPT) = property value × assessment level (20%) × (RPT 2% + SEF 1%)</div>
+          <div>Association dues = dues/sqm × floor area × 12, growing with inflation</div>
+          <div>Closing costs ≈ 5% = DST 1.5% + transfer ~0.75% + registration ~0.5% + professional</div>
+          <div>Selling costs ≈ 9.5% = CGT 6% + broker ~3% + notarial (if you assume a sale)</div>
+        </Formula>
+        <Body>
+          Defaults are anchored to May 2026 Philippine figures: bank fixed mortgage ~6.75% (Pag-IBIG
+          presets at 3% / ~6.25% are one click away), condo appreciation ~4%, association dues ₱100 /
+          sqm, and a 7% investment return — the floor set by Pag-IBIG MP2&apos;s tax-free 7.12%.
+        </Body>
+      </DocSection>
+
+      <Divider />
+
+      <DocSection>
+        <SectionLabel>Rent vs. Buy a Home</SectionLabel>
+        <SectionTitle>Beyond a Single Answer</SectionTitle>
+        <Body>
+          A single break-even year is false precision when appreciation and returns are uncertain. So
+          the tool adds three decision layers on top of the base simulation:
+        </Body>
+        <Formula>
+          <div>P(buying wins) — ~2,000 Monte-Carlo runs sampling appreciation, return, rent growth</div>
+          <div>Goal-seek — the exact appreciation / return / rent that flips the verdict (bisection)</div>
+          <div>Sensitivity — how far net worth swings when each input shifts ±20%</div>
+        </Formula>
+        <Note>
+          All figures can be switched to today&apos;s pesos (inflation-adjusted), and any scenario is
+          shareable via a link that encodes every input — no account needed.
+        </Note>
+      </DocSection>
+    </>
+  );
+}

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -4,6 +4,31 @@ import { Divider } from "./_components/doc-primitives";
 import { FxSection } from "./_components/fx-section";
 import { InstallmentSection } from "./_components/installment-section";
 import { RentVsBuySection } from "./_components/rent-vs-buy-section";
+import { JsonLd } from "@/components/json-ld";
+import { faqPageLd } from "@/app/_lib/seo";
+
+const FAQ = [
+  {
+    q: "Which Philippine credit card has the lowest foreign transaction fee?",
+    a: "Forex markups range from 0% on a few cards (e.g. some UnionBank and promo cards) up to ~3.5% on standard cards. The Card FX Comparison tool ranks 30+ PH cards by their all-in markup and simulates the peso cost of a purchase on live rates.",
+  },
+  {
+    q: "Is Wise or Payoneer cheaper for Filipino freelancers?",
+    a: "Wise usually converts closest to the mid-market rate (under ~1%), while Payoneer adds roughly 2% plus a possible annual inactivity fee. The Freelancer Payout Comparison computes the net pesos each option leaves after receiving, FX, and cash-out fees.",
+  },
+  {
+    q: "What is balance conversion and credit-to-cash?",
+    a: "Balance conversion turns an existing credit-card balance into fixed monthly installments at a quoted monthly rate; credit-to-cash disburses cash against your credit limit on similar terms. The Installment Calculator compares both, including the effective interest rate.",
+  },
+  {
+    q: "Should I rent or buy a condo in the Philippines?",
+    a: "It depends on appreciation, your mortgage rate, rent, and the return you'd earn investing your down payment instead. The Rent vs. Buy tool runs a year-by-year wealth simulation and shows the break-even year plus the probability buying wins.",
+  },
+  {
+    q: "How is car loan monthly amortization computed?",
+    a: "Most PH banks quote an add-on rate or an effective rate; the monthly payment is a standard annuity on the financed amount. The Car Financing Comparison converts any rate mode into a monthly payment and total cost so options compare fairly.",
+  },
+];
 
 export const metadata: Metadata = {
   title: "Savvy Spender - Documentation",
@@ -39,6 +64,7 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <div className="container mx-auto px-4 py-10 max-w-3xl">
+      <JsonLd data={faqPageLd(FAQ)} />
       <div className="mb-10">
         <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-3">
           Reference

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -3,16 +3,18 @@ import { CarFinancingSection } from "./_components/car-financing-section";
 import { Divider } from "./_components/doc-primitives";
 import { FxSection } from "./_components/fx-section";
 import { InstallmentSection } from "./_components/installment-section";
+import { RentVsBuySection } from "./_components/rent-vs-buy-section";
 
 export const metadata: Metadata = {
   title: "Savvy Spender - Documentation",
   description:
-    "How each calculator works — inputs, formulas, and what the results mean. Covers the Installment Calculator, Card FX Comparison, and Car Financing Comparison tools.",
+    "How each calculator works — inputs, formulas, and what the results mean. Covers the Installment Calculator, Card FX Comparison, Car Financing Comparison, and Rent vs. Buy a Home tools.",
   keywords: [
     "Payment Calculator Documentation",
     "Installment Calculator Documentation",
     "Card FX Comparison Documentation",
     "Car Financing Comparison Documentation",
+    "Rent vs Buy Calculator Philippines",
     "Balance Conversion Calculator",
     "Credit-to-Cash Calculator",
     "Financial Calculations Philippines",
@@ -57,6 +59,9 @@ export default function Page() {
       <Divider strong />
 
       <CarFinancingSection />
+      <Divider strong />
+
+      <RentVsBuySection />
       <Divider strong />
 
       <p className="text-xs text-muted-foreground leading-relaxed">

--- a/app/fx-compare/_components/comparison-table.tsx
+++ b/app/fx-compare/_components/comparison-table.tsx
@@ -121,11 +121,11 @@ export function ComparisonTable({
 
         {/* Mobile: stacked cards */}
         <div className="md:hidden space-y-2">
-          {displayData.map((entry, i) => {
+          {displayData.map((entry) => {
             const phpCost = computePhpCost(entry);
             return (
               <div
-                key={i}
+                key={`${entry.issuer}-${entry.card}`}
                 className={cn(
                   "rounded-md border p-3",
                   entry.hasZeroMarkup
@@ -193,11 +193,11 @@ export function ComparisonTable({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {displayData.map((entry, i) => {
+              {displayData.map((entry) => {
                 const phpCost = computePhpCost(entry);
                 return (
                   <TableRow
-                    key={i}
+                    key={`${entry.issuer}-${entry.card}`}
                     className={cn(entry.hasZeroMarkup && "bg-emerald-50/50 dark:bg-emerald-950/20")}
                   >
                     <TableCell className="font-medium">{entry.issuer}</TableCell>

--- a/app/fx-compare/_components/comparison-table.tsx
+++ b/app/fx-compare/_components/comparison-table.tsx
@@ -76,7 +76,54 @@ export function ComparisonTable({
         </div>
       </CardHeader>
       <CardContent>
-        <div className="overflow-x-auto -mx-6 px-6">
+        {/* Mobile: stacked cards */}
+        <div className="md:hidden space-y-2">
+          {sortedData.map((entry, i) => {
+            const phpCost = computePhpCost(entry);
+            return (
+              <div
+                key={i}
+                className={cn(
+                  "rounded-md border p-3",
+                  entry.hasZeroMarkup
+                    ? "border-emerald-500/40 bg-emerald-50/50 dark:bg-emerald-950/20"
+                    : "border-border"
+                )}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="font-medium text-sm">{entry.issuer}</p>
+                    <p className="text-[12px] text-muted-foreground">{entry.card}</p>
+                    <div className="mt-1.5">
+                      <NetworkBadge network={entry.network} />
+                    </div>
+                  </div>
+                  <div className="text-right shrink-0">
+                    {entry.hasZeroMarkup ? (
+                      <Badge
+                        variant="outline"
+                        className="bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900 font-mono-label text-[9px] uppercase tracking-[0.12em]"
+                      >
+                        0% — Free
+                      </Badge>
+                    ) : (
+                      <span className="text-sm tabular-nums">{entry.fxMarkup.toFixed(1)}% markup</span>
+                    )}
+                    {phpCost !== null && (
+                      <p className="text-sm font-medium tabular-nums mt-1">
+                        ₱{phpCost.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <p className="mt-2 text-[11px] text-muted-foreground leading-relaxed">{entry.notes}</p>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Desktop: table */}
+        <div className="hidden md:block overflow-x-auto -mx-6 px-6">
           <Table>
             <TableHeader>
               <TableRow>

--- a/app/fx-compare/_components/comparison-table.tsx
+++ b/app/fx-compare/_components/comparison-table.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Table,
@@ -27,12 +28,28 @@ export function ComparisonTable({
   phpPerUnit: number | null;
   currencyName: string;
 }) {
+  const [zeroOnly, setZeroOnly] = useState(false);
+  const [network, setNetwork] = useState<string>("all");
+
+  const networks = useMemo(
+    () => Array.from(new Set(CARD_FX_DATA.map((c) => c.network))).sort(),
+    []
+  );
+
   const sortedData = useMemo(
     () =>
       [...CARD_FX_DATA].sort(
         (a, b) => a.fxMarkup - b.fxMarkup || a.issuer.localeCompare(b.issuer)
       ),
     []
+  );
+
+  const displayData = useMemo(
+    () =>
+      sortedData.filter(
+        (c) => (!zeroOnly || c.hasZeroMarkup) && (network === "all" || c.network === network)
+      ),
+    [sortedData, zeroOnly, network]
   );
 
   const computePhpCost = useCallback(
@@ -76,9 +93,35 @@ export function ComparisonTable({
         </div>
       </CardHeader>
       <CardContent>
+        {/* Filter bar */}
+        <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+          <label className="flex items-center gap-2 text-[11px] text-muted-foreground cursor-pointer select-none">
+            <Checkbox checked={zeroOnly} onCheckedChange={(v) => setZeroOnly(Boolean(v))} />
+            0% forex only
+          </label>
+          <label className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            Network
+            <select
+              value={network}
+              onChange={(e) => setNetwork(e.target.value)}
+              className="h-7 rounded-sm border bg-background px-2 text-[11px]"
+            >
+              <option value="all">All</option>
+              {networks.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+          <span className="font-mono-label text-[10px] uppercase tracking-[0.15em] text-muted-foreground opacity-60">
+            {displayData.length} {displayData.length === 1 ? "card" : "cards"}
+          </span>
+        </div>
+
         {/* Mobile: stacked cards */}
         <div className="md:hidden space-y-2">
-          {sortedData.map((entry, i) => {
+          {displayData.map((entry, i) => {
             const phpCost = computePhpCost(entry);
             return (
               <div
@@ -150,7 +193,7 @@ export function ComparisonTable({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {sortedData.map((entry, i) => {
+              {displayData.map((entry, i) => {
                 const phpCost = computePhpCost(entry);
                 return (
                   <TableRow

--- a/app/fx-compare/layout.tsx
+++ b/app/fx-compare/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { JsonLd } from "@/components/json-ld";
+import { breadcrumbLd, buildToolMetadata } from "@/app/_lib/seo";
+
+export const metadata: Metadata = buildToolMetadata({
+  title: "Card FX Comparison",
+  description:
+    "Find the Philippine credit card with the lowest foreign transaction fee. Compare forex markups across 30+ cards and simulate the peso cost of any foreign or online purchase on live rates.",
+  path: "/fx-compare",
+  keywords: [
+    "no foreign transaction fee credit card philippines",
+    "credit card forex markup philippines",
+    "best card for online shopping abroad",
+    "0% forex credit card philippines",
+    "visa mastercard foreign transaction fee",
+    "card fx comparison",
+  ],
+});
+
+export default function FxCompareLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <JsonLd
+        data={breadcrumbLd([
+          { name: "Home", path: "/" },
+          { name: "Card FX Comparison", path: "/fx-compare" },
+        ])}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/fx-compare/page.tsx
+++ b/app/fx-compare/page.tsx
@@ -5,6 +5,16 @@ import { ComparisonTable } from "./_components/comparison-table";
 import { DisclaimerCard } from "./_components/disclaimer-card";
 import { SimulatorSidebar } from "./_components/simulator-sidebar";
 import { useFxRates } from "./_lib/use-fx-rates";
+import { ToolHeader } from "@/app/_components/tool-header";
+import { HowItWorks } from "@/app/_components/how-it-works";
+import { Glossary } from "@/app/_components/glossary";
+
+const FX_GLOSSARY = [
+  { term: "Mid-market rate", def: "The real interbank rate with no markup — the benchmark every card is measured against." },
+  { term: "FX markup", def: "The total % your card adds over the mid-market rate on a foreign charge." },
+  { term: "Network assessment", def: "Visa (~1%) or Mastercard (~0.2–1%) cross-border fee, usually bundled into the markup." },
+  { term: "0% forex", def: "Cards that waive the bank's markup; the network assessment may still apply." },
+];
 
 export default function FxComparePage() {
   const rateState = useFxRates();
@@ -22,18 +32,10 @@ export default function FxComparePage() {
 
   return (
     <main className="max-w-7xl mx-auto px-4 py-6 sm:py-8">
-      <div className="mb-8 max-w-3xl">
-        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-2">
-          Tool
-        </p>
-        <h1 className="font-display font-extralight text-3xl sm:text-4xl lg:text-5xl tracking-[-0.03em]">
-          Card FX Comparison
-        </h1>
-        <p className="mt-3 text-sm sm:text-base text-muted-foreground leading-relaxed">
-          See which PH credit card is cheapest to use abroad. Compare foreign transaction markups
-          across major card issuers and simulate the PHP cost of any foreign purchase.
-        </p>
-      </div>
+      <ToolHeader
+        title="Card FX Comparison"
+        description="See which PH credit card is cheapest to use abroad. Compare foreign transaction markups across major card issuers and simulate the PHP cost of any foreign purchase."
+      />
 
       <div className="grid lg:grid-cols-[280px_1fr] gap-6 lg:gap-10">
         <aside className="lg:sticky lg:top-20 lg:self-start space-y-5">
@@ -50,13 +52,21 @@ export default function FxComparePage() {
           <DisclaimerCard />
         </aside>
 
-        <section className="min-w-0">
+        <section className="min-w-0 space-y-5">
           <ComparisonTable
             selectedCurrency={selectedCurrency}
             foreignAmount={foreignAmount}
             phpPerUnit={phpPerUnit}
             currencyName={currencyName}
           />
+          <HowItWorks
+            docsHref="/docs"
+            points={[
+              { heading: "What it does", body: "Ranks PH credit cards by their all-in foreign-transaction markup and shows the peso cost of a purchase at the live mid-market rate." },
+              { heading: "Reading it", body: "Lower markup = cheaper abroad. A 0% card keeps the full mid-market value; standard cards add ~1.5–3.5%." },
+            ]}
+          />
+          <Glossary items={FX_GLOSSARY} />
         </section>
       </div>
     </main>

--- a/app/fx-compare/page.tsx
+++ b/app/fx-compare/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 import { ComparisonTable } from "./_components/comparison-table";
 import { DisclaimerCard } from "./_components/disclaimer-card";
 import { SimulatorSidebar } from "./_components/simulator-sidebar";
@@ -8,6 +8,8 @@ import { useFxRates } from "./_lib/use-fx-rates";
 import { ToolHeader } from "@/app/_components/tool-header";
 import { HowItWorks } from "@/app/_components/how-it-works";
 import { Glossary } from "@/app/_components/glossary";
+import { CopyLinkButton } from "@/app/_components/copy-link-button";
+import { useQueryState } from "@/lib/use-query-state";
 
 const FX_GLOSSARY = [
   { term: "Mid-market rate", def: "The real interbank rate with no markup — the benchmark every card is measured against." },
@@ -16,11 +18,16 @@ const FX_GLOSSARY = [
   { term: "0% forex", def: "Cards that waive the bank's markup; the network assessment may still apply." },
 ];
 
-export default function FxComparePage() {
+const FX_DEFAULTS = { currency: "USD", amount: 100 };
+const FX_CODES = { currency: "c", amount: "a" } as const;
+
+function FxCompare() {
   const rateState = useFxRates();
-  const [selectedCurrency, setSelectedCurrency] = useState("USD");
-  const [foreignAmount, setForeignAmount] = useState<number>(100);
+  const [state, patch] = useQueryState(FX_DEFAULTS, FX_CODES);
   const [search, setSearch] = useState("");
+
+  const selectedCurrency = state.currency;
+  const foreignAmount = state.amount;
 
   const phpPerUnit = useMemo(() => {
     if (!rateState.rates || !rateState.rates[selectedCurrency]) return null;
@@ -31,44 +38,54 @@ export default function FxComparePage() {
     rateState.currencies.find((c) => c.code === selectedCurrency)?.name ?? selectedCurrency;
 
   return (
+    <div className="grid lg:grid-cols-[280px_1fr] gap-6 lg:gap-10">
+      <aside className="lg:sticky lg:top-20 lg:self-start space-y-5">
+        <SimulatorSidebar
+          state={rateState}
+          foreignAmount={foreignAmount}
+          setForeignAmount={(n) => patch({ amount: n })}
+          selectedCurrency={selectedCurrency}
+          setSelectedCurrency={(c) => patch({ currency: c })}
+          search={search}
+          setSearch={setSearch}
+          phpPerUnit={phpPerUnit}
+        />
+        <DisclaimerCard />
+      </aside>
+
+      <section className="min-w-0 space-y-5">
+        <div className="flex justify-end">
+          <CopyLinkButton />
+        </div>
+        <ComparisonTable
+          selectedCurrency={selectedCurrency}
+          foreignAmount={foreignAmount}
+          phpPerUnit={phpPerUnit}
+          currencyName={currencyName}
+        />
+        <HowItWorks
+          docsHref="/docs"
+          points={[
+            { heading: "What it does", body: "Ranks PH credit cards by their all-in foreign-transaction markup and shows the peso cost of a purchase at the live mid-market rate." },
+            { heading: "Reading it", body: "Lower markup = cheaper abroad. A 0% card keeps the full mid-market value; standard cards add ~1.5–3.5%." },
+          ]}
+        />
+        <Glossary items={FX_GLOSSARY} />
+      </section>
+    </div>
+  );
+}
+
+export default function FxComparePage() {
+  return (
     <main className="max-w-7xl mx-auto px-4 py-6 sm:py-8">
       <ToolHeader
         title="Card FX Comparison"
         description="See which PH credit card is cheapest to use abroad. Compare foreign transaction markups across major card issuers and simulate the PHP cost of any foreign purchase."
       />
-
-      <div className="grid lg:grid-cols-[280px_1fr] gap-6 lg:gap-10">
-        <aside className="lg:sticky lg:top-20 lg:self-start space-y-5">
-          <SimulatorSidebar
-            state={rateState}
-            foreignAmount={foreignAmount}
-            setForeignAmount={setForeignAmount}
-            selectedCurrency={selectedCurrency}
-            setSelectedCurrency={setSelectedCurrency}
-            search={search}
-            setSearch={setSearch}
-            phpPerUnit={phpPerUnit}
-          />
-          <DisclaimerCard />
-        </aside>
-
-        <section className="min-w-0 space-y-5">
-          <ComparisonTable
-            selectedCurrency={selectedCurrency}
-            foreignAmount={foreignAmount}
-            phpPerUnit={phpPerUnit}
-            currencyName={currencyName}
-          />
-          <HowItWorks
-            docsHref="/docs"
-            points={[
-              { heading: "What it does", body: "Ranks PH credit cards by their all-in foreign-transaction markup and shows the peso cost of a purchase at the live mid-market rate." },
-              { heading: "Reading it", body: "Lower markup = cheaper abroad. A 0% card keeps the full mid-market value; standard cards add ~1.5–3.5%." },
-            ]}
-          />
-          <Glossary items={FX_GLOSSARY} />
-        </section>
-      </div>
+      <Suspense fallback={<div className="py-10 text-sm text-muted-foreground">Loading…</div>}>
+        <FxCompare />
+      </Suspense>
     </main>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,8 +9,6 @@ import Footer from "@/components/footer";
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
 };
 
 export const metadata: Metadata = {

--- a/app/loan-compare/_components/amortization-card.tsx
+++ b/app/loan-compare/_components/amortization-card.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronDownIcon, ChevronUpIcon, DownloadIcon } from "@radix-ui/react-icons";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/client";
+import { downloadCsv } from "@/lib/csv";
+import type { OptionResult } from "../_lib/types";
+
+/**
+ * Scheduled-payment timeline for one option. Mode-agnostic: it shows the fixed
+ * monthly payment, the running total paid, and the remaining scheduled balance
+ * (total repayment − paid so far) — accurate regardless of the rate mode used.
+ */
+export const AmortizationCard: React.FC<{ result: OptionResult }> = ({ result }) => {
+  const [open, setOpen] = useState(false);
+
+  const rows = useMemo(() => {
+    const payment = result.monthlyPayment;
+    const total = result.totalLoanPayments;
+    const out: { month: number; payment: number; paid: number; remaining: number }[] = [];
+    for (let m = 1; m <= result.termMonths; m++) {
+      const paid = payment * m;
+      out.push({
+        month: m,
+        payment,
+        paid,
+        remaining: m === result.termMonths ? 0 : Math.max(0, total - paid),
+      });
+    }
+    return out;
+  }, [result.monthlyPayment, result.totalLoanPayments, result.termMonths]);
+
+  const exportCsv = () => {
+    downloadCsv(
+      `payment-schedule-${result.name || "option"}`,
+      ["Month", "Payment", "Total paid", "Remaining"],
+      rows.map((r) => [r.month, r.payment.toFixed(2), r.paid.toFixed(2), r.remaining.toFixed(2)])
+    );
+  };
+
+  if (rows.length === 0) return null;
+
+  return (
+    <Card className="border-border">
+      <CardHeader className="cursor-pointer pb-3" onClick={() => setOpen((o) => !o)} role="button" aria-expanded={open}>
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+              Payment schedule
+            </p>
+            <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">{result.name}</CardTitle>
+            <CardDescription className="text-[12px] mt-1">
+              <span className="tabular-nums">{result.termMonths}</span> months ·{" "}
+              {formatCurrency(result.monthlyPayment)}/mo (lowest-total option)
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5 font-mono-label text-[10px] uppercase tracking-[0.12em]"
+              aria-label="Download payment schedule as CSV"
+              onClick={(e) => {
+                e.stopPropagation();
+                exportCsv();
+              }}
+            >
+              <DownloadIcon className="h-3.5 w-3.5" />
+              CSV
+            </Button>
+            <Button variant="ghost" size="icon" aria-label={open ? "Collapse" : "Expand"}>
+              {open ? <ChevronUpIcon className="h-4 w-4" /> : <ChevronDownIcon className="h-4 w-4" />}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      {open && (
+        <CardContent>
+          <div className="max-h-[420px] overflow-y-auto -mx-6 px-6 border-t">
+            <table className="w-full text-sm">
+              <thead className="sticky top-0 bg-card z-10">
+                <tr className="border-b">
+                  {["Month", "Payment", "Total paid", "Remaining"].map((h, i) => (
+                    <th
+                      key={h}
+                      className={`font-mono-label text-[10px] uppercase tracking-[0.18em] text-muted-foreground opacity-60 py-2 px-3 ${
+                        i === 0 ? "text-left" : "text-right"
+                      }`}
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.month} className="border-b last:border-0">
+                    <td className="py-1.5 px-3 tabular-nums font-medium">{r.month}</td>
+                    <td className="py-1.5 px-3 text-right tabular-nums">{formatCurrency(r.payment)}</td>
+                    <td className="py-1.5 px-3 text-right tabular-nums text-muted-foreground">{formatCurrency(r.paid)}</td>
+                    <td className="py-1.5 px-3 text-right tabular-nums">{formatCurrency(r.remaining)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="text-[11px] text-muted-foreground/80 mt-3 leading-relaxed">
+            Shows the scheduled monthly payment and what remains of total repayment. Early settlement
+            usually requires the outstanding principal plus any pre-termination fee — confirm the payoff
+            figure with the lender, as add-on interest is often not waived.
+          </p>
+        </CardContent>
+      )}
+    </Card>
+  );
+};

--- a/app/loan-compare/_components/option-list-editor.tsx
+++ b/app/loan-compare/_components/option-list-editor.tsx
@@ -4,6 +4,7 @@ import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { OptionCard } from "./option-card";
 import { SectionLabel } from "./form-controls";
+import { LOAN_PRESETS } from "../_lib/presets";
 import type { DiscountAppliesTo } from "../_lib/options";
 import type { FinancingOption } from "../_lib/types";
 
@@ -14,8 +15,9 @@ export const OptionListEditor: React.FC<{
   onDuplicate: (id: string) => void;
   onRemove: (id: string) => void;
   onAdd: () => void;
+  onAddPreset: (option: FinancingOption) => void;
   disabled?: boolean;
-}> = ({ options, discountAppliesTo, onUpdate, onDuplicate, onRemove, onAdd, disabled }) => (
+}> = ({ options, discountAppliesTo, onUpdate, onDuplicate, onRemove, onAdd, onAddPreset, disabled }) => (
   <div className="space-y-3">
     <div className="flex items-center justify-between">
       <SectionLabel>Financing options ({options.length})</SectionLabel>
@@ -30,6 +32,24 @@ export const OptionListEditor: React.FC<{
         <Plus className="h-3.5 w-3.5" />
         Add option
       </Button>
+    </div>
+
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="font-mono-label text-[10px] uppercase tracking-[0.15em] text-muted-foreground opacity-60 mr-1">
+        Quick add
+      </span>
+      {LOAN_PRESETS.map((preset) => (
+        <button
+          key={preset.key}
+          type="button"
+          disabled={disabled}
+          onClick={() => onAddPreset(preset.build())}
+          title={preset.note}
+          className="rounded-sm border border-dashed border-border px-2.5 py-1 text-[11px] text-muted-foreground transition-colors hover:border-foreground/50 hover:text-foreground disabled:opacity-60"
+        >
+          + {preset.label}
+        </button>
+      ))}
     </div>
 
     <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 items-start">

--- a/app/loan-compare/_components/tco-card.tsx
+++ b/app/loan-compare/_components/tco-card.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/client";
+import { NumField } from "./form-controls";
+
+interface TcoCardProps {
+  vehiclePrice: number; // net vehicle price of the reference option
+  financingCost: number; // total cost of the lowest-total option
+  optionName: string;
+}
+
+/**
+ * Opt-in total-cost-of-ownership estimate layered on top of the financing cost:
+ * adds fuel over the holding period and subtracts the car's estimated resale
+ * value. Assumptions are editable and clearly indicative (PH market, 2026):
+ * ~20% depreciation year 1, ~15%/yr after; gasoline ~₱65/L; ~12 km/L.
+ */
+export const TcoCard: React.FC<TcoCardProps> = ({ vehiclePrice, financingCost, optionName }) => {
+  const [years, setYears] = useState(5);
+  const [annualKm, setAnnualKm] = useState(15000);
+  const [fuelPrice, setFuelPrice] = useState(65);
+  const [kmPerL, setKmPerL] = useState(12);
+  const [firstYearDep, setFirstYearDep] = useState(20);
+  const [laterDep, setLaterDep] = useState(15);
+
+  const { resaleValue, retentionPct, fuelTotal, tco } = useMemo(() => {
+    const y = Math.max(0, Math.round(years));
+    const retention =
+      y <= 0 ? 1 : (1 - firstYearDep / 100) * Math.pow(1 - laterDep / 100, Math.max(0, y - 1));
+    const resale = vehiclePrice * retention;
+    const fuel = kmPerL > 0 ? y * (annualKm / kmPerL) * fuelPrice : 0;
+    return {
+      resaleValue: resale,
+      retentionPct: retention * 100,
+      fuelTotal: fuel,
+      tco: financingCost + fuel - resale,
+    };
+  }, [years, annualKm, fuelPrice, kmPerL, firstYearDep, laterDep, vehiclePrice, financingCost]);
+
+  return (
+    <Card className="border-border">
+      <CardHeader className="pb-3">
+        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+          Total cost of ownership
+        </p>
+        <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
+          Beyond the loan — fuel &amp; resale
+        </CardTitle>
+        <p className="text-[12px] text-muted-foreground mt-1">
+          Layers fuel and estimated resale onto the lowest-total option ({optionName}). Edit the
+          assumptions — they&apos;re indicative PH 2026 figures, and Japanese brands hold value better.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <NumField label="Years owned" value={years} onChange={setYears} step={1} />
+          <NumField label="Km / year" value={annualKm} onChange={setAnnualKm} step={1000} />
+          <NumField label="Fuel ₱ / liter" value={fuelPrice} onChange={setFuelPrice} step={1} />
+          <NumField label="Fuel economy (km/L)" value={kmPerL} onChange={setKmPerL} step={0.5} />
+          <NumField
+            label="Year-1 depreciation %"
+            value={firstYearDep}
+            onChange={setFirstYearDep}
+            step={1}
+            tip="New cars typically lose ~20% in the first year (up to 25% with heavy use)."
+          />
+          <NumField
+            label="Later depreciation %/yr"
+            value={laterDep}
+            onChange={setLaterDep}
+            step={1}
+            tip="After year 1, ~15%/yr is typical; well-holding models lose ~10%."
+          />
+        </div>
+
+        <dl className="rounded-sm border bg-muted/20 divide-y text-sm">
+          <Row label="Financing total cost" value={formatCurrency(financingCost)} />
+          <Row label={`Fuel over ${Math.max(0, Math.round(years))} yrs`} value={`+ ${formatCurrency(fuelTotal)}`} />
+          <Row
+            label={`Est. resale value (${retentionPct.toFixed(0)}% retained)`}
+            value={`− ${formatCurrency(resaleValue)}`}
+          />
+          <div className="flex items-center justify-between px-3 py-2.5">
+            <dt className="font-medium">Net cost of ownership</dt>
+            <dd className="tabular-nums font-semibold">{formatCurrency(tco)}</dd>
+          </div>
+        </dl>
+        <p className="text-[11px] text-muted-foreground/80 leading-relaxed">
+          Estimate only. Excludes insurance renewals, maintenance, parking, and tolls. Resale assumes
+          average condition; actual offers vary by brand, mileage, and demand.
+        </p>
+      </CardContent>
+    </Card>
+  );
+};
+
+const Row: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="flex items-center justify-between px-3 py-2">
+    <dt className="text-muted-foreground">{label}</dt>
+    <dd className="tabular-nums">{value}</dd>
+  </div>
+);

--- a/app/loan-compare/_lib/presets.ts
+++ b/app/loan-compare/_lib/presets.ts
@@ -1,0 +1,77 @@
+import { newOption } from "./defaults";
+import type { FinancingOption } from "./types";
+
+/**
+ * One-click financing templates grounded in 2026 PH market rates — bank auto
+ * loans run ~6–9% effective, dealer in-house ~15–30%, and credit-to-cash from
+ * ~0.49%/month. Each appends a pre-filled option you can then tweak.
+ */
+export interface LoanPreset {
+  key: string;
+  label: string;
+  note: string;
+  build: () => FinancingOption;
+}
+
+export const LOAN_PRESETS: LoanPreset[] = [
+  {
+    key: "bank-low",
+    label: "Bank auto loan · 6.5%",
+    note: "Effective rate, 60 mo",
+    build: () =>
+      newOption({
+        name: "Bank auto loan (6.5%)",
+        type: "bank_auto_loan",
+        provider: "Bank",
+        monthlyMode: "annual_effective",
+        annualEffectiveRate: 6.5,
+        termMonths: 60,
+        paymentTiming: "oma",
+      }),
+  },
+  {
+    key: "bank-high",
+    label: "Bank auto loan · 9%",
+    note: "Effective rate, 60 mo",
+    build: () =>
+      newOption({
+        name: "Bank auto loan (9%)",
+        type: "bank_auto_loan",
+        provider: "Bank",
+        monthlyMode: "annual_effective",
+        annualEffectiveRate: 9,
+        termMonths: 60,
+        paymentTiming: "oma",
+      }),
+  },
+  {
+    key: "inhouse",
+    label: "Dealer in-house · 18%",
+    note: "Effective rate, 36 mo",
+    build: () =>
+      newOption({
+        name: "Dealer in-house (18%)",
+        type: "in_house_financing",
+        provider: "Dealer",
+        monthlyMode: "annual_effective",
+        annualEffectiveRate: 18,
+        termMonths: 36,
+        paymentTiming: "oma",
+      }),
+  },
+  {
+    key: "c2c",
+    label: "Credit-to-cash · 0.49%/mo",
+    note: "Add-on, 24 mo",
+    build: () =>
+      newOption({
+        name: "Credit-to-cash (0.49%)",
+        type: "credit_to_cash",
+        provider: "Credit card",
+        monthlyMode: "monthly_addon",
+        monthlyAddOnRate: 0.49,
+        termMonths: 24,
+        paymentTiming: "arrears",
+      }),
+  },
+];

--- a/app/loan-compare/layout.tsx
+++ b/app/loan-compare/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { JsonLd } from "@/components/json-ld";
+import { breadcrumbLd, buildToolMetadata } from "@/app/_lib/seo";
+
+export const metadata: Metadata = buildToolMetadata({
+  title: "Car Financing Comparison",
+  description:
+    "Compare car loan options side by side — bank auto loans, in-house dealer financing, and credit-to-cash — with monthly amortization, total cost of ownership, and a priority-based recommendation.",
+  path: "/loan-compare",
+  keywords: [
+    "car loan calculator philippines",
+    "auto loan amortization philippines",
+    "car financing comparison philippines",
+    "in-house vs bank car financing",
+    "monthly amortization car loan",
+    "car loan interest rate philippines",
+  ],
+});
+
+export default function LoanCompareLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <JsonLd
+        data={breadcrumbLd([
+          { name: "Home", path: "/" },
+          { name: "Car Financing Comparison", path: "/loan-compare" },
+        ])}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/loan-compare/page.tsx
+++ b/app/loan-compare/page.tsx
@@ -2,7 +2,10 @@
 
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
+import { Download } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { downloadCsv } from "@/lib/csv";
 import { ActionBar } from "./_components/action-bar";
 import { CompareSettings } from "./_components/compare-settings";
 import { EmptyResults } from "./_components/empty-results";
@@ -54,6 +57,28 @@ export default function LoanComparePage() {
       options: [...p.options, newOption({ name: `Option ${p.options.length + 1}` })],
     }));
   }, []);
+
+  const addPresetOption = useCallback((option: FinancingOption) => {
+    setScenario((p) => ({ ...p, options: [...p.options, option] }));
+  }, []);
+
+  const exportCsv = useCallback(() => {
+    if (!response) return;
+    downloadCsv(
+      "car-financing-comparison",
+      ["Option", "Type", "Provider", "Term (mo)", "Monthly", "Total interest", "Upfront cash", "Total cost"],
+      response.results.map((r) => [
+        r.name,
+        r.typeLabel,
+        r.provider || "",
+        r.termMonths,
+        r.monthlyPayment.toFixed(2),
+        r.totalInterest.toFixed(2),
+        r.upfrontCash.toFixed(2),
+        r.totalCost.toFixed(2),
+      ])
+    );
+  }, [response]);
 
   const duplicateOption = useCallback((id: string) => {
     setScenario((p) => {
@@ -166,6 +191,7 @@ export default function LoanComparePage() {
           discountAppliesTo={scenario.vehicle.discountAppliesTo}
           onUpdate={updateOption}
           onAdd={addOption}
+          onAddPreset={addPresetOption}
           onDuplicate={duplicateOption}
           onRemove={removeOption}
           disabled={isLoading}
@@ -180,6 +206,15 @@ export default function LoanComparePage() {
 
         {response ? (
           <div className="space-y-6 pt-4">
+            <div className="flex items-center justify-between gap-3">
+              <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+                Results
+              </p>
+              <Button variant="outline" size="sm" onClick={exportCsv} className="gap-1.5">
+                <Download className="h-3.5 w-3.5" />
+                Export CSV
+              </Button>
+            </div>
             <ResultSummary results={response.results} cheapestId={response.cheapestId} />
             <KeyAssumptionsTable response={response} />
             <MonthlyPaymentTable results={response.results} cheapestId={response.cheapestId} />

--- a/app/loan-compare/page.tsx
+++ b/app/loan-compare/page.tsx
@@ -17,6 +17,7 @@ import { OptionListEditor } from "./_components/option-list-editor";
 import { RecommendationCard } from "./_components/recommendation-card";
 import { ResultSummary } from "./_components/result-summary";
 import { AmortizationCard } from "./_components/amortization-card";
+import { TcoCard } from "./_components/tco-card";
 import { SampleCallout } from "./_components/sample-callout";
 import { TotalCostTable } from "./_components/total-cost-table";
 import { UpfrontCashTable } from "./_components/upfront-cash-table";
@@ -229,7 +230,17 @@ export default function LoanComparePage() {
             {(() => {
               const cheapest =
                 response.results.find((r) => r.id === response.cheapestId) ?? response.results[0];
-              return cheapest ? <AmortizationCard result={cheapest} /> : null;
+              if (!cheapest) return null;
+              return (
+                <>
+                  <AmortizationCard result={cheapest} />
+                  <TcoCard
+                    vehiclePrice={cheapest.netVehiclePrice}
+                    financingCost={cheapest.totalCost}
+                    optionName={cheapest.name}
+                  />
+                </>
+              );
             })()}
             <RecommendationCard
               results={response.results}

--- a/app/loan-compare/page.tsx
+++ b/app/loan-compare/page.tsx
@@ -14,10 +14,11 @@ import { OptionListEditor } from "./_components/option-list-editor";
 import { RecommendationCard } from "./_components/recommendation-card";
 import { ResultSummary } from "./_components/result-summary";
 import { SampleCallout } from "./_components/sample-callout";
-import { SectionLabel } from "./_components/form-controls";
 import { TotalCostTable } from "./_components/total-cost-table";
 import { UpfrontCashTable } from "./_components/upfront-cash-table";
 import { VehicleSection } from "./_components/vehicle-section";
+import { ToolHeader } from "@/app/_components/tool-header";
+import { HowItWorks } from "@/app/_components/how-it-works";
 import { EMPTY_SCENARIO, SAMPLE_SCENARIO, newId, newOption } from "./_lib/defaults";
 import type { ComparisonScope, Priority } from "./_lib/options";
 import type {
@@ -133,18 +134,18 @@ export default function LoanComparePage() {
   return (
     <TooltipProvider delayDuration={200}>
       <main className="max-w-7xl mx-auto px-4 py-6 sm:py-8 space-y-6">
-        <header className="max-w-3xl">
-          <SectionLabel>Tool</SectionLabel>
-          <h1 className="font-display font-extralight text-3xl sm:text-4xl lg:text-5xl tracking-[-0.03em] mt-2">
-            Car Financing Comparison
-          </h1>
-          <p className="mt-3 text-sm sm:text-base text-muted-foreground leading-relaxed">
-            Compare any number of financing options — bank auto loans, credit-to-cash, personal
-            loans, dealer in-house, or fully custom — side by side. Six monthly-payment modes,
-            itemized fees with no double-counting, insurance and registration handling, and a
-            recommendation tuned to your priority.
-          </p>
-        </header>
+        <ToolHeader
+          title="Car Financing Comparison"
+          description="Compare any number of financing options — bank auto loans, credit-to-cash, personal loans, dealer in-house, or fully custom — side by side. Six monthly-payment modes, itemized fees with no double-counting, insurance and registration handling, and a recommendation tuned to your priority."
+        />
+
+        <HowItWorks
+          docsHref="/docs"
+          points={[
+            { heading: "What it does", body: "Converts any quoted rate mode (add-on, effective, nominal, or a flat quote) into a monthly payment and total cost, so bank, in-house, and cash-style options compare on equal terms." },
+            { heading: "Reading it", body: "Pick a comparison scope (full cost, loan-only, or upfront cash) and the recommendation updates to your chosen priority." },
+          ]}
+        />
 
         {showSampleCallout && <SampleCallout onLoad={handleLoadSample} />}
 

--- a/app/loan-compare/page.tsx
+++ b/app/loan-compare/page.tsx
@@ -16,6 +16,7 @@ import { MonthlyPaymentTable } from "./_components/monthly-payment-table";
 import { OptionListEditor } from "./_components/option-list-editor";
 import { RecommendationCard } from "./_components/recommendation-card";
 import { ResultSummary } from "./_components/result-summary";
+import { AmortizationCard } from "./_components/amortization-card";
 import { SampleCallout } from "./_components/sample-callout";
 import { TotalCostTable } from "./_components/total-cost-table";
 import { UpfrontCashTable } from "./_components/upfront-cash-table";
@@ -225,6 +226,11 @@ export default function LoanComparePage() {
               cheapestId={response.cheapestId}
               scope={response.scope}
             />
+            {(() => {
+              const cheapest =
+                response.results.find((r) => r.id === response.cheapestId) ?? response.results[0];
+              return cheapest ? <AmortizationCard result={cheapest} /> : null;
+            })()}
             <RecommendationCard
               results={response.results}
               recommendations={response.recommendations}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,14 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import { SectionRule, ToolCard } from "./_components/tool-card";
 import { SECONDARY_LINKS, TOOLS } from "./_lib/tools";
+import { JsonLd } from "@/components/json-ld";
+import { SITE_URL, webApplicationLd } from "./_lib/seo";
+
+export const metadata: Metadata = {
+  alternates: { canonical: SITE_URL },
+};
 
 export default function LandingPage() {
   const liveCount = TOOLS.filter((t) => t.status === "live").length;
@@ -9,6 +16,7 @@ export default function LandingPage() {
 
   return (
     <main>
+      <JsonLd data={webApplicationLd()} />
       {/* Hero */}
       <header className="container mx-auto px-4 pt-20 sm:pt-28 pb-12 landing-reveal">
         <p className="font-mono-label text-[10px] uppercase tracking-[0.3em] text-muted-foreground opacity-60 mb-4">
@@ -18,8 +26,8 @@ export default function LandingPage() {
           Savvy Spender
         </h1>
         <p className="mt-6 text-muted-foreground max-w-md leading-relaxed">
-          Calmly check the math before you sign. Installment calculator, card FX comparison, and
-          car financing comparison — with more on the way.
+          Calmly check the math before you sign. Installment and rent-vs-buy calculators, card FX and
+          freelancer-payout comparisons, and car financing — all free, no sign-up.
         </p>
         <div className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2">
           <Link

--- a/app/payout-compare/_components/comparison-table.tsx
+++ b/app/payout-compare/_components/comparison-table.tsx
@@ -64,7 +64,54 @@ export function ComparisonTable({
         </div>
       </CardHeader>
       <CardContent>
-        <div className="overflow-x-auto -mx-6 px-6">
+        {/* Mobile: stacked cards */}
+        <div className="md:hidden space-y-2">
+          {rows.map(({ platform, result }, i) => {
+            const isBest = live && i === 0;
+            return (
+              <div
+                key={platform.name}
+                className={cn(
+                  "rounded-md border p-3",
+                  isBest ? "border-emerald-500/40 bg-emerald-50/50 dark:bg-emerald-950/20" : "border-border"
+                )}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="font-medium text-sm">
+                      {platform.name}
+                      {isBest && (
+                        <Badge className="ml-2 bg-emerald-600 hover:bg-emerald-600 font-mono-label text-[9px] uppercase tracking-[0.12em]">
+                          Best
+                        </Badge>
+                      )}
+                    </p>
+                    <div className="mt-1.5 flex items-center gap-2">
+                      <CategoryBadge category={platform.category} />
+                      <span className="text-[11px] text-muted-foreground">{platform.payoutSpeed}</span>
+                    </div>
+                  </div>
+                  <div className="text-right shrink-0">
+                    {result ? (
+                      <>
+                        <p className="text-sm font-medium tabular-nums">{formatCurrency(result.netPhp)}</p>
+                        <p className="text-[11px] text-muted-foreground tabular-nums">
+                          {result.effectiveCostPct.toFixed(1)}% fee
+                        </p>
+                      </>
+                    ) : (
+                      <span className="text-[12px] text-muted-foreground tabular-nums">~{platform.fxMarkupPct}% FX</span>
+                    )}
+                  </div>
+                </div>
+                <p className="mt-2 text-[11px] text-muted-foreground leading-relaxed">{platform.notes}</p>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Desktop: table */}
+        <div className="hidden md:block overflow-x-auto -mx-6 px-6">
           <Table>
             <TableHeader>
               <TableRow>

--- a/app/payout-compare/_components/comparison-table.tsx
+++ b/app/payout-compare/_components/comparison-table.tsx
@@ -105,6 +105,7 @@ export function ComparisonTable({
                   </div>
                 </div>
                 <p className="mt-2 text-[11px] text-muted-foreground leading-relaxed">{platform.notes}</p>
+                <SourceTags sources={platform.sources} />
               </div>
             );
           })}
@@ -161,6 +162,7 @@ export function ComparisonTable({
                     )}
                     <TableCell className="text-[11px] text-muted-foreground max-w-[280px] leading-relaxed">
                       {platform.notes}
+                      <SourceTags sources={platform.sources} />
                     </TableCell>
                   </TableRow>
                 );
@@ -186,7 +188,11 @@ export function ComparisonTable({
                       rows[0].result.netPhp - rows[rows.length - 1].result!.netPhp
                     )}
                   </span>{" "}
-                  more than the costliest option here.
+                  more than the costliest option here — about{" "}
+                  <span className="font-medium tabular-nums">
+                    {formatCurrency((rows[0].result.netPhp - rows[rows.length - 1].result!.netPhp) * 12)}
+                  </span>{" "}
+                  a year if you&apos;re paid monthly.
                 </>
               )}
             </p>
@@ -196,6 +202,20 @@ export function ComparisonTable({
     </Card>
   );
 }
+
+const SourceTags: React.FC<{ sources?: string[] }> = ({ sources }) =>
+  sources && sources.length ? (
+    <span className="mt-1.5 flex flex-wrap gap-1">
+      {sources.map((s) => (
+        <span
+          key={s}
+          className="rounded-sm bg-muted px-1.5 py-0.5 font-mono-label text-[9px] uppercase tracking-[0.1em] text-muted-foreground"
+        >
+          {s}
+        </span>
+      ))}
+    </span>
+  ) : null;
 
 const Th: React.FC<{ children: React.ReactNode; className?: string }> = ({
   children,

--- a/app/payout-compare/_lib/data.ts
+++ b/app/payout-compare/_lib/data.ts
@@ -26,6 +26,7 @@ export const PAYOUT_PLATFORMS: PayoutPlatform[] = [
     withdrawFixedPhp: 0,
     payoutSpeed: "Seconds – 2 days",
     canHoldForeign: true,
+    sources: ["Direct client", "Upwork", "Invoicing"],
     notes:
       "Cheapest transparent option. Free USD receiving over local/ACH rails (a SWIFT wire costs ~$6); converts at the true mid-market rate for ~0.6%. Hold USD and convert when the rate suits you.",
   },
@@ -39,8 +40,10 @@ export const PAYOUT_PLATFORMS: PayoutPlatform[] = [
     withdrawFixedPhp: 0,
     payoutSpeed: "2 hrs – 2 days",
     canHoldForeign: true,
+    sources: ["Upwork", "Fiverr", "Marketplaces"],
+    inactivityFeeUsd: 29.95,
     notes:
-      "Built for marketplaces. Receiving from a marketplace/client is free–~1% (card-funded clients cost up to 3.99% + $0.49); withdrawing USD to a PHP bank adds up to ~2% over mid-market.",
+      "Built for marketplaces. Receiving from a marketplace/client is free–~1% (card-funded clients cost up to 3.99% + $0.49); withdrawing USD to a PHP bank adds up to ~2% over mid-market. Charges $29.95/yr if unused for 12 months.",
   },
   {
     name: "PayPal → PHP bank",
@@ -52,6 +55,7 @@ export const PAYOUT_PLATFORMS: PayoutPlatform[] = [
     withdrawFixedPhp: 50,
     payoutSpeed: "1–5 days",
     canHoldForeign: true,
+    sources: ["Fiverr", "Onlinejobs.ph", "Direct client"],
     notes:
       "Two stacked costs people miss: ~4.4% + ₱15 to receive an international goods-and-services payment, THEN a ~3–4% conversion spread to move USD→PHP. Bank withdrawal is ₱50 under ₱7,000, else free.",
   },
@@ -65,6 +69,7 @@ export const PAYOUT_PLATFORMS: PayoutPlatform[] = [
     withdrawFixedPhp: 0,
     payoutSpeed: "Instant – 1 day",
     canHoldForeign: false,
+    sources: ["Fiverr", "Onlinejobs.ph", "Direct client"],
     notes:
       "Cash-out to GCash is free, but you still pay PayPal's ~4.4% receiving fee and the ~3–4% USD→PHP conversion spread. GCash itself holds only pesos.",
   },
@@ -91,6 +96,7 @@ export const PAYOUT_PLATFORMS: PayoutPlatform[] = [
     withdrawFixedPhp: 0,
     payoutSpeed: "2–5 days",
     canHoldForeign: true,
+    sources: ["Direct client", "Enterprise"],
     notes:
       "Direct telegraphic transfer to a PHP bank (BPI/BDO). A stated inward SWIFT fee (~$14) plus possible intermediary-bank fees, but the bigger hidden cost is an undisclosed ~1–2.5% FX spread on conversion.",
   },
@@ -117,6 +123,7 @@ export const PAYOUT_PLATFORMS: PayoutPlatform[] = [
     withdrawFixedPhp: 10,
     payoutSpeed: "Minutes",
     canHoldForeign: true,
+    sources: ["Crypto-native client", "Web3"],
     notes:
       "Cheapest FX if the client pays in USDT. Sell on a licensed PH exchange with limit orders (~0.1–0.5% spot; the quick 'Convert' hides 1–3%); cash-out is free–₱10 via InstaPay/PESONet. Adds peg/liquidity risk and KYC.",
   },

--- a/app/payout-compare/_lib/types.ts
+++ b/app/payout-compare/_lib/types.ts
@@ -10,6 +10,8 @@ export interface PayoutPlatform {
   withdrawFixedPhp: number; // fixed cash-out fee, in PHP
   payoutSpeed: string;
   canHoldForeign: boolean; // can you hold a foreign-currency balance?
+  sources?: string[]; // where payments typically originate (Upwork, Fiverr, direct client, …)
+  inactivityFeeUsd?: number; // annual fee charged if the account goes unused
   notes: string;
 }
 

--- a/app/payout-compare/layout.tsx
+++ b/app/payout-compare/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { JsonLd } from "@/components/json-ld";
+import { breadcrumbLd, buildToolMetadata } from "@/app/_lib/seo";
+
+export const metadata: Metadata = buildToolMetadata({
+  title: "Freelancer Payout Comparison",
+  description:
+    "See which app nets a Filipino freelancer the most pesos — Wise, Payoneer, PayPal, GCash, banks, and crypto — after receiving fees, FX markup, and cash-out fees on a live mid-market rate.",
+  path: "/payout-compare",
+  keywords: [
+    "wise vs payoneer philippines",
+    "cheapest way to receive money from abroad philippines",
+    "freelancer payment philippines",
+    "payoneer fees philippines",
+    "get paid in usd philippines",
+    "wise vs paypal philippines",
+  ],
+});
+
+export default function PayoutCompareLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <JsonLd
+        data={breadcrumbLd([
+          { name: "Home", path: "/" },
+          { name: "Freelancer Payout Comparison", path: "/payout-compare" },
+        ])}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/payout-compare/page.tsx
+++ b/app/payout-compare/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 import { useFxRates } from "@/lib/fx";
 import { ComparisonTable } from "./_components/comparison-table";
 import { DisclaimerCard } from "./_components/disclaimer-card";
@@ -8,6 +8,8 @@ import { SimulatorSidebar } from "./_components/simulator-sidebar";
 import { ToolHeader } from "@/app/_components/tool-header";
 import { HowItWorks } from "@/app/_components/how-it-works";
 import { Glossary } from "@/app/_components/glossary";
+import { CopyLinkButton } from "@/app/_components/copy-link-button";
+import { useQueryState } from "@/lib/use-query-state";
 
 const PAYOUT_GLOSSARY = [
   { term: "Receiving fee", def: "Charged when the payment lands — a %, a fixed fee, or both." },
@@ -17,11 +19,16 @@ const PAYOUT_GLOSSARY = [
   { term: "Hold foreign", def: "Whether you can keep a USD balance instead of auto-converting on arrival." },
 ];
 
-export default function PayoutComparePage() {
+const PAYOUT_DEFAULTS = { currency: "USD", amount: 1000 };
+const PAYOUT_CODES = { currency: "c", amount: "a" } as const;
+
+function PayoutCompare() {
   const rateState = useFxRates();
-  const [selectedCurrency, setSelectedCurrency] = useState("USD");
-  const [amount, setAmount] = useState<number>(1000);
+  const [state, patch] = useQueryState(PAYOUT_DEFAULTS, PAYOUT_CODES);
   const [search, setSearch] = useState("");
+
+  const selectedCurrency = state.currency;
+  const amount = state.amount;
 
   const phpPerUnit = useMemo(() => {
     if (!rateState.rates || !rateState.rates[selectedCurrency]) return null;
@@ -29,44 +36,50 @@ export default function PayoutComparePage() {
   }, [rateState.rates, selectedCurrency]);
 
   return (
+    <div className="grid lg:grid-cols-[280px_1fr] gap-6 lg:gap-10">
+      <aside className="lg:sticky lg:top-20 lg:self-start space-y-5">
+        <SimulatorSidebar
+          state={rateState}
+          amount={amount}
+          setAmount={(n) => patch({ amount: n })}
+          selectedCurrency={selectedCurrency}
+          setSelectedCurrency={(c) => patch({ currency: c })}
+          search={search}
+          setSearch={setSearch}
+          phpPerUnit={phpPerUnit}
+        />
+        <DisclaimerCard />
+      </aside>
+
+      <section className="min-w-0 space-y-5">
+        <div className="flex justify-end">
+          <CopyLinkButton />
+        </div>
+        <ComparisonTable selectedCurrency={selectedCurrency} amount={amount} phpPerUnit={phpPerUnit} />
+        <HowItWorks
+          docsHref="/docs"
+          points={[
+            { heading: "What it does", body: "Computes the net pesos you keep after three fee layers — receiving fee, FX markup, and cash-out fee — on a live mid-market rate." },
+            { heading: "Reading it", body: "Rows are sorted by net PHP, so the top keeps the most of your money. Wise usually converts closest to mid-market; Payoneer adds ~2%; PayPal is typically costliest." },
+            { heading: "Tip", body: "If a platform lets you hold a foreign balance, you can convert when the rate is better instead of on arrival." },
+          ]}
+        />
+        <Glossary items={PAYOUT_GLOSSARY} />
+      </section>
+    </div>
+  );
+}
+
+export default function PayoutComparePage() {
+  return (
     <main className="max-w-7xl mx-auto px-4 py-6 sm:py-8">
       <ToolHeader
         title="Freelancer Payout Comparison"
         description="Getting paid by a client abroad? See which app puts the most pesos in your pocket. Compare Wise, Payoneer, PayPal, e-wallets, bank wires, remittance, and a crypto off-ramp — net of receiving fees, FX markup, and cash-out charges, on a live mid-market rate."
       />
-
-      <div className="grid lg:grid-cols-[280px_1fr] gap-6 lg:gap-10">
-        <aside className="lg:sticky lg:top-20 lg:self-start space-y-5">
-          <SimulatorSidebar
-            state={rateState}
-            amount={amount}
-            setAmount={setAmount}
-            selectedCurrency={selectedCurrency}
-            setSelectedCurrency={setSelectedCurrency}
-            search={search}
-            setSearch={setSearch}
-            phpPerUnit={phpPerUnit}
-          />
-          <DisclaimerCard />
-        </aside>
-
-        <section className="min-w-0 space-y-5">
-          <ComparisonTable
-            selectedCurrency={selectedCurrency}
-            amount={amount}
-            phpPerUnit={phpPerUnit}
-          />
-          <HowItWorks
-            docsHref="/docs"
-            points={[
-              { heading: "What it does", body: "Computes the net pesos you keep after three fee layers — receiving fee, FX markup, and cash-out fee — on a live mid-market rate." },
-              { heading: "Reading it", body: "Rows are sorted by net PHP, so the top keeps the most of your money. Wise usually converts closest to mid-market; Payoneer adds ~2%; PayPal is typically costliest." },
-              { heading: "Tip", body: "If a platform lets you hold a foreign balance, you can convert when the rate is better instead of on arrival." },
-            ]}
-          />
-          <Glossary items={PAYOUT_GLOSSARY} />
-        </section>
-      </div>
+      <Suspense fallback={<div className="py-10 text-sm text-muted-foreground">Loading…</div>}>
+        <PayoutCompare />
+      </Suspense>
     </main>
   );
 }

--- a/app/payout-compare/page.tsx
+++ b/app/payout-compare/page.tsx
@@ -5,6 +5,17 @@ import { useFxRates } from "@/lib/fx";
 import { ComparisonTable } from "./_components/comparison-table";
 import { DisclaimerCard } from "./_components/disclaimer-card";
 import { SimulatorSidebar } from "./_components/simulator-sidebar";
+import { ToolHeader } from "@/app/_components/tool-header";
+import { HowItWorks } from "@/app/_components/how-it-works";
+import { Glossary } from "@/app/_components/glossary";
+
+const PAYOUT_GLOSSARY = [
+  { term: "Receiving fee", def: "Charged when the payment lands — a %, a fixed fee, or both." },
+  { term: "FX markup", def: "The % over the mid-market rate when the platform converts to PHP." },
+  { term: "Cash-out fee", def: "Cost to move pesos from the platform to your bank or e-wallet." },
+  { term: "Inactivity fee", def: "Some platforms (e.g. Payoneer) charge an annual fee if the account goes unused." },
+  { term: "Hold foreign", def: "Whether you can keep a USD balance instead of auto-converting on arrival." },
+];
 
 export default function PayoutComparePage() {
   const rateState = useFxRates();
@@ -19,19 +30,10 @@ export default function PayoutComparePage() {
 
   return (
     <main className="max-w-7xl mx-auto px-4 py-6 sm:py-8">
-      <div className="mb-8 max-w-3xl">
-        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-2">
-          Tool
-        </p>
-        <h1 className="font-display font-extralight text-3xl sm:text-4xl lg:text-5xl tracking-[-0.03em]">
-          Freelancer Payout Comparison
-        </h1>
-        <p className="mt-3 text-sm sm:text-base text-muted-foreground leading-relaxed">
-          Getting paid by a client abroad? See which app puts the most pesos in your pocket. Compare
-          Wise, Payoneer, PayPal, e-wallets, bank wires, remittance, and a crypto off-ramp — net of
-          receiving fees, FX markup, and cash-out charges, on a live mid-market rate.
-        </p>
-      </div>
+      <ToolHeader
+        title="Freelancer Payout Comparison"
+        description="Getting paid by a client abroad? See which app puts the most pesos in your pocket. Compare Wise, Payoneer, PayPal, e-wallets, bank wires, remittance, and a crypto off-ramp — net of receiving fees, FX markup, and cash-out charges, on a live mid-market rate."
+      />
 
       <div className="grid lg:grid-cols-[280px_1fr] gap-6 lg:gap-10">
         <aside className="lg:sticky lg:top-20 lg:self-start space-y-5">
@@ -48,12 +50,21 @@ export default function PayoutComparePage() {
           <DisclaimerCard />
         </aside>
 
-        <section className="min-w-0">
+        <section className="min-w-0 space-y-5">
           <ComparisonTable
             selectedCurrency={selectedCurrency}
             amount={amount}
             phpPerUnit={phpPerUnit}
           />
+          <HowItWorks
+            docsHref="/docs"
+            points={[
+              { heading: "What it does", body: "Computes the net pesos you keep after three fee layers — receiving fee, FX markup, and cash-out fee — on a live mid-market rate." },
+              { heading: "Reading it", body: "Rows are sorted by net PHP, so the top keeps the most of your money. Wise usually converts closest to mid-market; Payoneer adds ~2%; PayPal is typically costliest." },
+              { heading: "Tip", body: "If a platform lets you hold a foreign balance, you can convert when the rate is better instead of on arrival." },
+            ]}
+          />
+          <Glossary items={PAYOUT_GLOSSARY} />
         </section>
       </div>
     </main>

--- a/app/rent-vs-buy/_components/assumptions-card.tsx
+++ b/app/rent-vs-buy/_components/assumptions-card.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 /** Methodology + the disclaimer every Savvy Spender tool carries. */
-export function AssumptionsCard() {
+export const AssumptionsCard: React.FC = () => {
   return (
     <Card className="border-border">
       <CardHeader className="pb-2">
@@ -33,4 +33,4 @@ export function AssumptionsCard() {
       </CardContent>
     </Card>
   );
-}
+};

--- a/app/rent-vs-buy/_components/assumptions-card.tsx
+++ b/app/rent-vs-buy/_components/assumptions-card.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+/** Methodology + the disclaimer every Savvy Spender tool carries. */
+export function AssumptionsCard() {
+  return (
+    <Card className="border-border">
+      <CardHeader className="pb-2">
+        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+          How this works
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-2.5 text-[12px] text-muted-foreground leading-relaxed">
+        <p>
+          Both paths start with the same cash. The buyer sinks it into the down payment and closing
+          costs; the renter keeps it invested. Each year the cheaper path invests the difference, so
+          net worth is compared apples-to-apples — buying&apos;s net worth is home equity plus any
+          invested surplus, renting&apos;s is the investment portfolio.
+        </p>
+        <p>
+          Ownership carries the mortgage, amilyar (RPT + SEF on the assessed value), association
+          dues, maintenance, and insurance. The home appreciates; rent escalates. The{" "}
+          <span className="text-foreground">probability buying wins</span> comes from ~2,000
+          Monte-Carlo runs that randomise appreciation, investment return, and rent growth around
+          your estimates.
+        </p>
+        <p className="border-t border-border pt-2.5 text-[11px]">
+          For reference only. Rates, taxes, and fees change and vary by bank, city, and property.
+          This is a model, not financial advice — verify with the relevant institutions before
+          deciding.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/rent-vs-buy/_components/breakeven-chart.tsx
+++ b/app/rent-vs-buy/_components/breakeven-chart.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/client";
+import { toRealPesos } from "../_lib/compute";
+import type { MonteCarloResult, RentVsBuyResult } from "../_lib/types";
+
+interface Props {
+  result: RentVsBuyResult;
+  mc: MonteCarloResult;
+  realPesos: boolean;
+}
+
+const compact = (n: number): string => {
+  const abs = Math.abs(n);
+  const sign = n < 0 ? "−" : "";
+  if (abs >= 1e6) return `${sign}₱${(abs / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `${sign}₱${(abs / 1e3).toFixed(0)}k`;
+  return `${sign}₱${abs.toFixed(0)}`;
+};
+
+/**
+ * The net-worth advantage of buying over renting, year by year. The line is the
+ * point estimate; the shaded fan is the P10–P90 range across ~2,000 Monte-Carlo
+ * scenarios. Buying breaks even where the line crosses zero.
+ */
+export function BreakevenChart({ result, mc, realPesos }: Props) {
+  const inflation = result.input.costInflationPct;
+
+  const data = useMemo(() => {
+    const adj = (v: number, year: number) => (realPesos ? toRealPesos(v, year, inflation) : v);
+    return result.rows.map((row, i) => {
+      const band = mc.bands[i];
+      const p10 = adj(band?.p10 ?? row.netWorthGap, row.year);
+      const p90 = adj(band?.p90 ?? row.netWorthGap, row.year);
+      return {
+        year: row.year,
+        gap: adj(row.netWorthGap, row.year),
+        p10,
+        span: Math.max(0, p90 - p10),
+        p50: adj(band?.p50 ?? row.netWorthGap, row.year),
+      };
+    });
+  }, [result.rows, mc.bands, realPesos, inflation]);
+
+  return (
+    <Card className="border-border">
+      <CardHeader className="pb-2">
+        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+          Break-even chart
+        </p>
+        <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
+          Buying&apos;s net-worth advantage over time
+        </CardTitle>
+        <p className="text-[12px] text-muted-foreground mt-1">
+          Above the line = buying is ahead. Shaded band spans the P10–P90 range across{" "}
+          {mc.runs.toLocaleString()} scenarios.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="w-full h-[320px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={data} margin={{ top: 8, right: 8, left: 4, bottom: 4 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" opacity={0.4} />
+              <XAxis
+                dataKey="year"
+                tick={{ fontSize: 11 }}
+                stroke="hsl(var(--muted-foreground))"
+                label={{ value: "Year", position: "insideBottom", offset: -2, fontSize: 11 }}
+              />
+              <YAxis
+                tickFormatter={compact}
+                tick={{ fontSize: 11 }}
+                stroke="hsl(var(--muted-foreground))"
+                width={56}
+              />
+              <Tooltip
+                formatter={(value, name) =>
+                  name === "Advantage" || name === "Median"
+                    ? [formatCurrency(Number(value)), String(name)]
+                    : null
+                }
+                labelFormatter={(y) => `Year ${y}`}
+                contentStyle={{
+                  borderRadius: "8px",
+                  border: "1px solid hsl(var(--border))",
+                  background: "hsl(var(--card))",
+                  fontSize: "12px",
+                }}
+              />
+              {/* P10–P90 fan: invisible base + visible span */}
+              <Area
+                dataKey="p10"
+                stackId="band"
+                stroke="none"
+                fill="none"
+                isAnimationActive={false}
+                legendType="none"
+                name="_base"
+              />
+              <Area
+                dataKey="span"
+                stackId="band"
+                stroke="none"
+                fill="hsl(221, 83%, 53%)"
+                fillOpacity={0.12}
+                isAnimationActive={false}
+                legendType="none"
+                name="_span"
+              />
+              <ReferenceLine y={0} stroke="hsl(var(--muted-foreground))" strokeDasharray="4 4" />
+              {result.breakEvenYear && (
+                <ReferenceLine
+                  x={result.breakEvenYear}
+                  stroke="hsl(142, 71%, 45%)"
+                  strokeDasharray="4 4"
+                  label={{
+                    value: `break-even ·  yr ${result.breakEvenYear}`,
+                    fontSize: 10,
+                    fill: "hsl(142, 71%, 45%)",
+                    position: "top",
+                  }}
+                />
+              )}
+              <Line
+                type="monotone"
+                dataKey="p50"
+                stroke="hsl(221, 83%, 53%)"
+                strokeWidth={1}
+                strokeDasharray="3 3"
+                dot={false}
+                isAnimationActive={false}
+                name="Median"
+              />
+              <Line
+                type="monotone"
+                dataKey="gap"
+                stroke="hsl(221, 83%, 53%)"
+                strokeWidth={2.5}
+                dot={false}
+                isAnimationActive={false}
+                name="Advantage"
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/rent-vs-buy/_components/breakeven-chart.tsx
+++ b/app/rent-vs-buy/_components/breakeven-chart.tsx
@@ -36,7 +36,7 @@ const compact = (n: number): string => {
  * point estimate; the shaded fan is the P10–P90 range across ~2,000 Monte-Carlo
  * scenarios. Buying breaks even where the line crosses zero.
  */
-export function BreakevenChart({ result, mc, realPesos }: Props) {
+export const BreakevenChart: React.FC<Props> = ({ result, mc, realPesos }) => {
   const inflation = result.input.costInflationPct;
 
   const data = useMemo(() => {
@@ -159,4 +159,4 @@ export function BreakevenChart({ result, mc, realPesos }: Props) {
       </CardContent>
     </Card>
   );
-}
+};

--- a/app/rent-vs-buy/_components/financing-presets.tsx
+++ b/app/rent-vs-buy/_components/financing-presets.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { FINANCING_PRESETS } from "../_lib/presets";
+import type { RentVsBuyInput } from "../_lib/types";
+
+interface Props {
+  input: RentVsBuyInput;
+  onApply: (overrides: Partial<RentVsBuyInput>) => void;
+}
+
+/** Quick Philippine financing profiles that prefill rate / term / down payment. */
+export function FinancingPresets({ input, onApply }: Props) {
+  return (
+    <Card className="border-border">
+      <CardHeader className="pb-3">
+        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+          Financing profile
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {FINANCING_PRESETS.map((preset) => {
+          const active =
+            input.mortgageRatePct === preset.overrides.mortgageRatePct &&
+            input.loanTermYears === preset.overrides.loanTermYears &&
+            input.downPaymentPct === preset.overrides.downPaymentPct;
+          return (
+            <button
+              key={preset.key}
+              type="button"
+              onClick={() => onApply(preset.overrides)}
+              className={cn(
+                "w-full text-left rounded-sm border px-3 py-2 transition-colors",
+                active
+                  ? "border-foreground bg-foreground/[0.03]"
+                  : "border-border hover:border-foreground/40"
+              )}
+            >
+              <span className="block text-sm font-medium">{preset.label}</span>
+              <span className="block text-[11px] text-muted-foreground">{preset.note}</span>
+            </button>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/rent-vs-buy/_components/financing-presets.tsx
+++ b/app/rent-vs-buy/_components/financing-presets.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 /** Quick Philippine financing profiles that prefill rate / term / down payment. */
-export function FinancingPresets({ input, onApply }: Props) {
+export const FinancingPresets: React.FC<Props> = ({ input, onApply }) => {
   return (
     <Card className="border-border">
       <CardHeader className="pb-3">
@@ -45,4 +45,4 @@ export function FinancingPresets({ input, onApply }: Props) {
       </CardContent>
     </Card>
   );
-}
+};

--- a/app/rent-vs-buy/_components/goal-seek-card.tsx
+++ b/app/rent-vs-buy/_components/goal-seek-card.tsx
@@ -10,7 +10,7 @@ import type { RentVsBuyInput } from "../_lib/types";
  * Goal-seek: the precise belief each lever needs for the verdict to flip. Turns
  * "buying wins" into a falsifiable claim the user can check against the market.
  */
-export function GoalSeekCard({ input }: { input: RentVsBuyInput }) {
+export const GoalSeekCard: React.FC<{ input: RentVsBuyInput }> = ({ input }) => {
   const items = useMemo(() => {
     const appr = solveForBreakEven(input, "appreciationPct", -5, 20);
     const ret = solveForBreakEven(input, "investReturnPct", 0, 20);
@@ -60,4 +60,4 @@ export function GoalSeekCard({ input }: { input: RentVsBuyInput }) {
       </CardContent>
     </Card>
   );
-}
+};

--- a/app/rent-vs-buy/_components/goal-seek-card.tsx
+++ b/app/rent-vs-buy/_components/goal-seek-card.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/client";
+import { solveForBreakEven } from "../_lib/solver";
+import type { RentVsBuyInput } from "../_lib/types";
+
+/**
+ * Goal-seek: the precise belief each lever needs for the verdict to flip. Turns
+ * "buying wins" into a falsifiable claim the user can check against the market.
+ */
+export function GoalSeekCard({ input }: { input: RentVsBuyInput }) {
+  const items = useMemo(() => {
+    const appr = solveForBreakEven(input, "appreciationPct", -5, 20);
+    const ret = solveForBreakEven(input, "investReturnPct", 0, 20);
+    const rent = solveForBreakEven(input, "monthlyRent", 0, Math.max(80_000, input.monthlyRent * 4));
+
+    return [
+      {
+        label: "Appreciation needed",
+        body: appr.solved
+          ? `Buying breaks even if the home appreciates at least ${appr.value}% / yr (you assumed ${input.appreciationPct}%).`
+          : appr.message,
+      },
+      {
+        label: "Return that flips it",
+        body: ret.solved
+          ? `Renting wins once your investments return more than ${ret.value}% / yr (you assumed ${input.investReturnPct}%).`
+          : ret.message,
+      },
+      {
+        label: "Rent threshold",
+        body: rent.solved
+          ? `Buying wins only while equivalent rent stays above ${formatCurrency(rent.value!)} / mo (you assumed ${formatCurrency(input.monthlyRent)}).`
+          : rent.message,
+      },
+    ];
+  }, [input]);
+
+  return (
+    <Card className="border-border">
+      <CardHeader className="pb-2">
+        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+          Goal-seek
+        </p>
+        <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
+          What you&apos;d have to believe
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {items.map((item) => (
+          <div key={item.label} className="rounded-sm border border-border px-3 py-2">
+            <p className="font-mono-label text-[9px] uppercase tracking-[0.16em] text-muted-foreground opacity-60 mb-0.5">
+              {item.label}
+            </p>
+            <p className="text-sm leading-relaxed">{item.body}</p>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/rent-vs-buy/_components/inputs-form.tsx
+++ b/app/rent-vs-buy/_components/inputs-form.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { FIELD_GROUPS } from "../_lib/defaults";
+import type { RentVsBuyInput } from "../_lib/types";
+
+interface Props {
+  input: RentVsBuyInput;
+  onChange: <K extends keyof RentVsBuyInput>(key: K, value: RentVsBuyInput[K]) => void;
+  realPesos: boolean;
+  setRealPesos: (v: boolean) => void;
+}
+
+export function InputsForm({ input, onChange, realPesos, setRealPesos }: Props) {
+  return (
+    <Card className="border-border">
+      <CardHeader className="pb-3">
+        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+          Your scenario
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {FIELD_GROUPS.map((group) => (
+          <div key={group.title}>
+            <p className="font-mono-label text-[10px] uppercase tracking-[0.18em] text-foreground/70 mb-2">
+              {group.title}
+            </p>
+            <div className="grid grid-cols-2 gap-3">
+              {group.fields.map((f) => (
+                <NumField
+                  key={f.key}
+                  label={f.label}
+                  tip={f.tip}
+                  suffix={f.suffix}
+                  step={f.step}
+                  value={input[f.key] as number}
+                  onChange={(v) => onChange(f.key, v as RentVsBuyInput[typeof f.key])}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+
+        <div className="space-y-2 pt-1 border-t">
+          <CheckRow
+            label="Assume you sell at the horizon (nets selling costs from equity)"
+            checked={input.assumeSaleAtHorizon}
+            onChange={(v) => onChange("assumeSaleAtHorizon", v)}
+          />
+          <CheckRow
+            label="Show figures in today's pesos (inflation-adjusted)"
+            checked={realPesos}
+            onChange={setRealPesos}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function NumField({
+  label,
+  tip,
+  suffix,
+  step,
+  value,
+  onChange,
+}: {
+  label: string;
+  tip: string;
+  suffix?: string;
+  step: number;
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div>
+      <Label className="font-mono-label text-[10px] uppercase tracking-[0.14em] text-muted-foreground opacity-70 mb-1 flex items-center gap-1">
+        <span className="truncate">{label}</span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <InfoCircledIcon className="h-3 w-3 shrink-0 text-muted-foreground cursor-help" />
+          </TooltipTrigger>
+          <TooltipContent side="top" className="max-w-[240px] text-xs font-normal leading-relaxed">
+            {tip}
+          </TooltipContent>
+        </Tooltip>
+      </Label>
+      <div className="relative">
+        <Input
+          type="number"
+          min={0}
+          step={step}
+          value={value === 0 ? "" : value}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(+e.target.value || 0)}
+          className="tabular-nums h-9 text-sm pr-12"
+          placeholder="0"
+        />
+        {suffix && (
+          <span className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-[10px] text-muted-foreground">
+            {suffix}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CheckRow({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-start gap-2 text-[11px] text-muted-foreground cursor-pointer select-none leading-relaxed">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={(v) => onChange(Boolean(v))}
+        className="mt-0.5"
+      />
+      {label}
+    </label>
+  );
+}

--- a/app/rent-vs-buy/_components/inputs-form.tsx
+++ b/app/rent-vs-buy/_components/inputs-form.tsx
@@ -17,7 +17,7 @@ interface Props {
   setRealPesos: (v: boolean) => void;
 }
 
-export function InputsForm({ input, onChange, realPesos, setRealPesos }: Props) {
+export const InputsForm: React.FC<Props> = ({ input, onChange, realPesos, setRealPesos }) => {
   return (
     <Card className="border-border">
       <CardHeader className="pb-3">
@@ -62,23 +62,18 @@ export function InputsForm({ input, onChange, realPesos, setRealPesos }: Props) 
       </CardContent>
     </Card>
   );
-}
+};
 
-function NumField({
-  label,
-  tip,
-  suffix,
-  step,
-  value,
-  onChange,
-}: {
+interface NumFieldProps {
   label: string;
   tip: string;
   suffix?: string;
   step: number;
   value: number;
   onChange: (v: number) => void;
-}) {
+}
+
+const NumField: React.FC<NumFieldProps> = ({ label, tip, suffix, step, value, onChange }) => {
   return (
     <div>
       <Label className="font-mono-label text-[10px] uppercase tracking-[0.14em] text-muted-foreground opacity-70 mb-1 flex items-center gap-1">
@@ -110,17 +105,15 @@ function NumField({
       </div>
     </div>
   );
-}
+};
 
-function CheckRow({
-  label,
-  checked,
-  onChange,
-}: {
+interface CheckRowProps {
   label: string;
   checked: boolean;
   onChange: (v: boolean) => void;
-}) {
+}
+
+const CheckRow: React.FC<CheckRowProps> = ({ label, checked, onChange }) => {
   return (
     <label className="flex items-start gap-2 text-[11px] text-muted-foreground cursor-pointer select-none leading-relaxed">
       <Checkbox
@@ -131,4 +124,4 @@ function CheckRow({
       {label}
     </label>
   );
-}
+};

--- a/app/rent-vs-buy/_components/price-to-rent-gauge.tsx
+++ b/app/rent-vs-buy/_components/price-to-rent-gauge.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
  * Price-to-rent ratio (price ÷ annual rent) — the classic at-a-glance heuristic.
  * <15 favours buying, 15–20 is a toss-up, >20 favours renting.
  */
-export function PriceToRentGauge({ ratio }: { ratio: number }) {
+export const PriceToRentGauge: React.FC<{ ratio: number }> = ({ ratio }) => {
   const verdict = ratio < 15 ? "Buy-favoured" : ratio <= 20 ? "Borderline" : "Rent-favoured";
   const color =
     ratio < 15 ? "text-emerald-600 dark:text-emerald-400" : ratio <= 20 ? "text-amber-600 dark:text-amber-400" : "text-sky-600 dark:text-sky-400";
@@ -48,4 +48,4 @@ export function PriceToRentGauge({ ratio }: { ratio: number }) {
       </CardContent>
     </Card>
   );
-}
+};

--- a/app/rent-vs-buy/_components/price-to-rent-gauge.tsx
+++ b/app/rent-vs-buy/_components/price-to-rent-gauge.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+/**
+ * Price-to-rent ratio (price ÷ annual rent) — the classic at-a-glance heuristic.
+ * <15 favours buying, 15–20 is a toss-up, >20 favours renting.
+ */
+export function PriceToRentGauge({ ratio }: { ratio: number }) {
+  const verdict = ratio < 15 ? "Buy-favoured" : ratio <= 20 ? "Borderline" : "Rent-favoured";
+  const color =
+    ratio < 15 ? "text-emerald-600 dark:text-emerald-400" : ratio <= 20 ? "text-amber-600 dark:text-amber-400" : "text-sky-600 dark:text-sky-400";
+  // Map ratio 5..30 → 0..100% for the marker position.
+  const pos = Math.min(100, Math.max(0, ((ratio - 5) / 25) * 100));
+
+  return (
+    <Card className="border-border">
+      <CardHeader className="pb-2">
+        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+          Price-to-rent ratio
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-baseline gap-2">
+          <span className="tabular-nums font-display font-light text-3xl">{ratio.toFixed(1)}</span>
+          <span className={cn("text-sm font-medium", color)}>{verdict}</span>
+        </div>
+        <div className="relative mt-3 h-2.5 rounded-full overflow-hidden flex">
+          <div className="h-full bg-emerald-500/40" style={{ width: "40%" }} />
+          <div className="h-full bg-amber-500/40" style={{ width: "20%" }} />
+          <div className="h-full bg-sky-500/40" style={{ width: "40%" }} />
+          <div
+            className="absolute top-1/2 -translate-y-1/2 h-4 w-1 rounded-full bg-foreground"
+            style={{ left: `calc(${pos}% - 2px)` }}
+          />
+        </div>
+        <div className="flex justify-between text-[10px] text-muted-foreground mt-1 font-mono-label">
+          <span>5</span>
+          <span>15</span>
+          <span>20</span>
+          <span>30+</span>
+        </div>
+        <p className="text-[11px] text-muted-foreground mt-2 leading-relaxed">
+          A quick sanity check independent of the full simulation: how many years of rent equal the
+          purchase price.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/rent-vs-buy/_components/result-summary.tsx
+++ b/app/rent-vs-buy/_components/result-summary.tsx
@@ -13,7 +13,7 @@ interface Props {
   realPesos: boolean;
 }
 
-export function ResultSummary({ result, mc, realPesos }: Props) {
+export const ResultSummary: React.FC<Props> = ({ result, mc, realPesos }) => {
   const horizon = result.input.horizonYears;
   const inflation = result.input.costInflationPct;
   const show = (v: number) => formatCurrency(realPesos ? toRealPesos(v, horizon, inflation) : v);
@@ -93,19 +93,16 @@ export function ResultSummary({ result, mc, realPesos }: Props) {
       </div>
     </div>
   );
-}
+};
 
-function Stat({
-  label,
-  value,
-  hint,
-  accent,
-}: {
+interface StatProps {
   label: string;
   value: string;
   hint?: string;
   accent?: "emerald" | "sky" | "amber";
-}) {
+}
+
+const Stat: React.FC<StatProps> = ({ label, value, hint, accent }) => {
   return (
     <Card className="border-border">
       <CardContent className="py-3">
@@ -126,4 +123,4 @@ function Stat({
       </CardContent>
     </Card>
   );
-}
+};

--- a/app/rent-vs-buy/_components/result-summary.tsx
+++ b/app/rent-vs-buy/_components/result-summary.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/client";
+import { toRealPesos } from "../_lib/compute";
+import type { MonteCarloResult, RentVsBuyResult } from "../_lib/types";
+
+interface Props {
+  result: RentVsBuyResult;
+  mc: MonteCarloResult;
+  realPesos: boolean;
+}
+
+export function ResultSummary({ result, mc, realPesos }: Props) {
+  const horizon = result.input.horizonYears;
+  const inflation = result.input.costInflationPct;
+  const show = (v: number) => formatCurrency(realPesos ? toRealPesos(v, horizon, inflation) : v);
+
+  const buyWins = result.buyWins;
+  const gap = Math.abs(result.buyNetWorthAtHorizon - result.rentNetWorthAtHorizon);
+  const pPct = Math.round(mc.pBuyWins * 100);
+
+  return (
+    <div className="space-y-4">
+      {/* Verdict banner */}
+      <Card
+        className={cn(
+          "border-2",
+          buyWins
+            ? "border-emerald-500/50 bg-emerald-50/50 dark:bg-emerald-950/20"
+            : "border-sky-500/50 bg-sky-50/50 dark:bg-sky-950/20"
+        )}
+      >
+        <CardContent className="py-4">
+          <div className="flex items-start justify-between gap-3 flex-wrap">
+            <div>
+              <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-70">
+                Verdict over {horizon} years
+              </p>
+              <p className="font-display font-light text-2xl sm:text-3xl tracking-tight mt-1">
+                {buyWins ? "Buying comes out ahead" : "Renting comes out ahead"}
+              </p>
+              <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
+                {buyWins ? "Buying" : "Renting"} leaves you{" "}
+                <span className="font-medium text-foreground tabular-nums">{show(gap)}</span> richer
+                {result.breakEvenYear
+                  ? ` — buying overtakes renting in year ${result.breakEvenYear}.`
+                  : " — buying never overtakes renting within your horizon."}
+              </p>
+            </div>
+            <Badge
+              className={cn(
+                "font-mono-label text-[10px] uppercase tracking-[0.12em] shrink-0",
+                pPct >= 50
+                  ? "bg-emerald-600 hover:bg-emerald-600"
+                  : "bg-sky-600 hover:bg-sky-600"
+              )}
+            >
+              {pPct}% chance buying wins
+            </Badge>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Stat grid */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <Stat label="Buy net worth" value={show(result.buyNetWorthAtHorizon)} accent="emerald" />
+        <Stat label="Rent net worth" value={show(result.rentNetWorthAtHorizon)} accent="sky" />
+        <Stat label="Monthly mortgage" value={formatCurrency(result.monthlyMortgage)} />
+        <Stat label="Upfront cash" value={formatCurrency(result.upfrontCash)} />
+        <Stat
+          label="Break-even year"
+          value={result.breakEvenYear ? `Year ${result.breakEvenYear}` : "Never"}
+        />
+        <Stat
+          label="Typical break-even"
+          value={mc.breakEvenP50 ? `~Year ${mc.breakEvenP50}` : "Beyond horizon"}
+          hint={`across ${mc.runs.toLocaleString()} scenarios`}
+        />
+        <Stat label="Total interest" value={formatCurrency(result.totalInterest)} />
+        {result.mortgagePctOfIncome !== null ? (
+          <Stat
+            label="Mortgage of income"
+            value={`${result.mortgagePctOfIncome.toFixed(0)}%`}
+            accent={result.mortgagePctOfIncome > 30 ? "amber" : undefined}
+            hint={result.mortgagePctOfIncome > 30 ? "above the ~30% rule" : "within the ~30% rule"}
+          />
+        ) : (
+          <Stat label="Price-to-rent" value={result.priceToRent.toFixed(1)} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  hint,
+  accent,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  accent?: "emerald" | "sky" | "amber";
+}) {
+  return (
+    <Card className="border-border">
+      <CardContent className="py-3">
+        <p className="font-mono-label text-[9px] uppercase tracking-[0.16em] text-muted-foreground opacity-60">
+          {label}
+        </p>
+        <p
+          className={cn(
+            "tabular-nums text-base font-medium mt-1",
+            accent === "emerald" && "text-emerald-600 dark:text-emerald-400",
+            accent === "sky" && "text-sky-600 dark:text-sky-400",
+            accent === "amber" && "text-amber-600 dark:text-amber-400"
+          )}
+        >
+          {value}
+        </p>
+        {hint && <p className="text-[10px] text-muted-foreground mt-0.5">{hint}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/rent-vs-buy/_components/sensitivity-tornado.tsx
+++ b/app/rent-vs-buy/_components/sensitivity-tornado.tsx
@@ -14,7 +14,7 @@ const compact = (n: number): string => {
  * Ranked bars showing how far the net-worth verdict swings when each assumption
  * is shifted ±20%. The longest bar is the lever the decision hinges on.
  */
-export function SensitivityTornado({ bars }: { bars: SensitivityBar[] }) {
+export const SensitivityTornado: React.FC<{ bars: SensitivityBar[] }> = ({ bars }) => {
   const maxSwing = Math.max(1, ...bars.map((b) => b.swing));
 
   return (
@@ -48,4 +48,4 @@ export function SensitivityTornado({ bars }: { bars: SensitivityBar[] }) {
       </CardContent>
     </Card>
   );
-}
+};

--- a/app/rent-vs-buy/_components/sensitivity-tornado.tsx
+++ b/app/rent-vs-buy/_components/sensitivity-tornado.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { SensitivityBar } from "../_lib/types";
+
+const compact = (n: number): string => {
+  const abs = Math.abs(n);
+  if (abs >= 1e6) return `₱${(n / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `₱${(n / 1e3).toFixed(0)}k`;
+  return `₱${n.toFixed(0)}`;
+};
+
+/**
+ * Ranked bars showing how far the net-worth verdict swings when each assumption
+ * is shifted ±20%. The longest bar is the lever the decision hinges on.
+ */
+export function SensitivityTornado({ bars }: { bars: SensitivityBar[] }) {
+  const maxSwing = Math.max(1, ...bars.map((b) => b.swing));
+
+  return (
+    <Card className="border-border">
+      <CardHeader className="pb-2">
+        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+          Sensitivity
+        </p>
+        <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
+          What moves the answer most
+        </CardTitle>
+        <p className="text-[12px] text-muted-foreground mt-1">
+          Net-worth swing at the horizon when each input is shifted ±20%. The top lever decides it.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-2.5">
+        {bars.map((bar) => (
+          <div key={String(bar.key)}>
+            <div className="flex items-center justify-between text-[12px] mb-1">
+              <span className="font-medium">{bar.label}</span>
+              <span className="tabular-nums text-muted-foreground">±{compact(bar.swing / 2)}</span>
+            </div>
+            <div className="h-2.5 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full rounded-full bg-blue-500/70"
+                style={{ width: `${(bar.swing / maxSwing) * 100}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/rent-vs-buy/_components/share-bar.tsx
+++ b/app/rent-vs-buy/_components/share-bar.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 /** Copy a shareable link encoding the exact scenario, or reset to defaults. */
-export function ShareBar({ input, onReset }: Props) {
+export const ShareBar: React.FC<Props> = ({ input, onReset }) => {
   const copyLink = async () => {
     const query = encodeInput(input);
     const url = `${window.location.origin}${window.location.pathname}${query ? `?${query}` : ""}`;
@@ -38,4 +38,4 @@ export function ShareBar({ input, onReset }: Props) {
       </Button>
     </div>
   );
-}
+};

--- a/app/rent-vs-buy/_components/share-bar.tsx
+++ b/app/rent-vs-buy/_components/share-bar.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Link2, RotateCcw } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { encodeInput } from "../_lib/url-state";
+import type { RentVsBuyInput } from "../_lib/types";
+
+interface Props {
+  input: RentVsBuyInput;
+  onReset: () => void;
+}
+
+/** Copy a shareable link encoding the exact scenario, or reset to defaults. */
+export function ShareBar({ input, onReset }: Props) {
+  const copyLink = async () => {
+    const query = encodeInput(input);
+    const url = `${window.location.origin}${window.location.pathname}${query ? `?${query}` : ""}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success("Shareable link copied", {
+        description: "Anyone who opens it sees this exact scenario.",
+      });
+    } catch {
+      toast.error("Couldn't copy — your browser blocked clipboard access.");
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="sm" onClick={copyLink} className="gap-1.5">
+        <Link2 className="h-3.5 w-3.5" />
+        Copy link
+      </Button>
+      <Button variant="ghost" size="sm" onClick={onReset} className="gap-1.5 text-muted-foreground">
+        <RotateCcw className="h-3.5 w-3.5" />
+        Reset
+      </Button>
+    </div>
+  );
+}

--- a/app/rent-vs-buy/_components/yearly-table.tsx
+++ b/app/rent-vs-buy/_components/yearly-table.tsx
@@ -11,7 +11,7 @@ interface Props {
   realPesos: boolean;
 }
 
-export function YearlyTable({ result, realPesos }: Props) {
+export const YearlyTable: React.FC<Props> = ({ result, realPesos }) => {
   const inflation = result.input.costInflationPct;
   const fmt = (v: number, year: number) =>
     formatCurrency(realPesos ? toRealPesos(v, year, inflation) : v);
@@ -79,19 +79,16 @@ export function YearlyTable({ result, realPesos }: Props) {
       </CardContent>
     </Card>
   );
-}
+};
 
-function Num({
-  children,
-  strong,
-  muted,
-  className,
-}: {
+interface NumProps {
   children: React.ReactNode;
   strong?: boolean;
   muted?: boolean;
   className?: string;
-}) {
+}
+
+const Num: React.FC<NumProps> = ({ children, strong, muted, className }) => {
   return (
     <td
       className={cn(
@@ -104,4 +101,4 @@ function Num({
       {children}
     </td>
   );
-}
+};

--- a/app/rent-vs-buy/_components/yearly-table.tsx
+++ b/app/rent-vs-buy/_components/yearly-table.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/client";
+import { toRealPesos } from "../_lib/compute";
+import type { RentVsBuyResult } from "../_lib/types";
+
+interface Props {
+  result: RentVsBuyResult;
+  realPesos: boolean;
+}
+
+export function YearlyTable({ result, realPesos }: Props) {
+  const inflation = result.input.costInflationPct;
+  const fmt = (v: number, year: number) =>
+    formatCurrency(realPesos ? toRealPesos(v, year, inflation) : v);
+
+  return (
+    <Card className="border-border">
+      <CardHeader className="pb-3">
+        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60">
+          Year-by-year
+        </p>
+        <CardTitle className="font-display font-light text-xl tracking-tight mt-0.5">
+          The full breakdown
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto -mx-6 px-6">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b">
+                {["Yr", "Property value", "Loan balance", "Buy equity", "Own / yr", "Rent / yr", "Buy net worth", "Rent net worth", "Gap"].map(
+                  (h, i) => (
+                    <th
+                      key={h}
+                      className={cn(
+                        "font-mono-label text-[10px] uppercase tracking-[0.14em] text-muted-foreground opacity-60 py-2 px-2.5 whitespace-nowrap",
+                        i === 0 ? "text-left" : "text-right"
+                      )}
+                    >
+                      {h}
+                    </th>
+                  )
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {result.rows.map((row) => {
+                const isBreakEven = row.year === result.breakEvenYear;
+                return (
+                  <tr
+                    key={row.year}
+                    className={cn(
+                      "border-b last:border-0",
+                      isBreakEven && "bg-emerald-50/50 dark:bg-emerald-950/20"
+                    )}
+                  >
+                    <td className="py-1.5 px-2.5 tabular-nums font-medium">{row.year}</td>
+                    <Num>{fmt(row.propertyValue, row.year)}</Num>
+                    <Num>{fmt(row.loanBalance, row.year)}</Num>
+                    <Num>{fmt(row.buyEquity, row.year)}</Num>
+                    <Num muted>{fmt(row.ownAnnualCost, row.year)}</Num>
+                    <Num muted>{fmt(row.rentAnnual, row.year)}</Num>
+                    <Num className="text-emerald-700 dark:text-emerald-400">
+                      {fmt(row.buyNetWorth, row.year)}
+                    </Num>
+                    <Num className="text-sky-700 dark:text-sky-400">
+                      {fmt(row.rentNetWorth, row.year)}
+                    </Num>
+                    <Num strong>{fmt(row.netWorthGap, row.year)}</Num>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Num({
+  children,
+  strong,
+  muted,
+  className,
+}: {
+  children: React.ReactNode;
+  strong?: boolean;
+  muted?: boolean;
+  className?: string;
+}) {
+  return (
+    <td
+      className={cn(
+        "py-1.5 px-2.5 text-right tabular-nums whitespace-nowrap",
+        strong && "font-semibold",
+        muted && "text-muted-foreground",
+        className
+      )}
+    >
+      {children}
+    </td>
+  );
+}

--- a/app/rent-vs-buy/_lib/compute.ts
+++ b/app/rent-vs-buy/_lib/compute.ts
@@ -1,0 +1,130 @@
+import type { RentVsBuyInput, RentVsBuyResult, YearRow } from "./types";
+
+const round = (n: number): number => Math.round(n * 100) / 100;
+
+/** Standard annuity payment: P·i / (1 − (1+i)^−n). Falls back to P/n when i = 0. */
+export function annuityPayment(principal: number, monthlyRate: number, months: number): number {
+  if (months <= 0) return 0;
+  if (monthlyRate <= 0) return principal / months;
+  const factor = Math.pow(1 + monthlyRate, -months);
+  return (principal * monthlyRate) / (1 - factor);
+}
+
+/** Remaining loan balance after `paymentsMade` monthly payments. */
+function remainingBalance(
+  principal: number,
+  monthlyRate: number,
+  totalMonths: number,
+  paymentsMade: number
+): number {
+  if (paymentsMade >= totalMonths) return 0;
+  if (monthlyRate <= 0) return principal * (1 - paymentsMade / totalMonths);
+  const pow = (k: number) => Math.pow(1 + monthlyRate, k);
+  return principal * ((pow(totalMonths) - pow(paymentsMade)) / (pow(totalMonths) - 1));
+}
+
+/**
+ * Year-by-year wealth simulation comparing owning a home against renting and
+ * investing the difference. The two paths share an identical annual housing
+ * budget — whoever spends less that year invests the surplus — so net worth is
+ * compared apples-to-apples. This is the single source of truth that the solver,
+ * sensitivity, and Monte-Carlo layers all call.
+ */
+export function simulate(input: RentVsBuyInput): RentVsBuyResult {
+  const horizon = Math.max(1, Math.round(input.horizonYears));
+  const termMonths = Math.max(0, Math.round(input.loanTermYears * 12));
+  const monthlyRate = input.mortgageRatePct / 100 / 12;
+
+  const downPayment = input.price * (input.downPaymentPct / 100);
+  const closingCosts = input.price * (input.closingCostPct / 100);
+  const loanPrincipal = Math.max(0, input.price - downPayment);
+  const upfrontCash = downPayment + closingCosts;
+  const monthlyMortgage = annuityPayment(loanPrincipal, monthlyRate, termMonths);
+  const totalInterest = monthlyMortgage * termMonths - loanPrincipal;
+
+  const app = input.appreciationPct / 100;
+  const rentGrowth = input.rentGrowthPct / 100;
+  const inflation = input.costInflationPct / 100;
+  const ret = input.investReturnPct / 100;
+  const rptEff = (input.assessmentLevelPct / 100) * ((input.rptRatePct + input.sefRatePct) / 100);
+  const sellFactor = input.assumeSaleAtHorizon ? 1 - input.sellingCostPct / 100 : 1;
+
+  // Both start with the same liquid cash. The buyer sinks it into the home, so
+  // the buyer's side-portfolio starts empty; the renter keeps it invested.
+  let buyInvestments = 0;
+  let rentPortfolio = upfrontCash;
+
+  let totalOwnOutlay = upfrontCash;
+  let totalRentOutlay = 0;
+
+  const rows: YearRow[] = [];
+
+  for (let year = 1; year <= horizon; year++) {
+    const propertyValue = input.price * Math.pow(1 + app, year);
+    const paymentsMade = Math.min(termMonths, year * 12);
+    const loanBalance = remainingBalance(loanPrincipal, monthlyRate, termMonths, paymentsMade);
+
+    // Owning out-of-pocket this year.
+    const mortgageThisYear = year * 12 <= termMonths ? monthlyMortgage * 12 : 0;
+    const amilyar = propertyValue * rptEff;
+    const dues = input.duesPerSqmMonthly * input.floorAreaSqm * 12 * Math.pow(1 + inflation, year - 1);
+    const maintenance = propertyValue * (input.maintenancePct / 100);
+    const insurance = propertyValue * (input.homeInsurancePct / 100);
+    const ownAnnualCost = mortgageThisYear + amilyar + dues + maintenance + insurance;
+
+    // Renting out-of-pocket this year.
+    const rentAnnual = input.monthlyRent * 12 * Math.pow(1 + rentGrowth, year - 1);
+
+    // Shared housing budget — the cheaper path invests the surplus.
+    const budget = Math.max(ownAnnualCost, rentAnnual);
+    buyInvestments = buyInvestments * (1 + ret) + (budget - ownAnnualCost);
+    rentPortfolio = rentPortfolio * (1 + ret) + (budget - rentAnnual);
+
+    const buyEquity = propertyValue * sellFactor - loanBalance;
+    const buyNetWorth = buyEquity + buyInvestments;
+    const rentNetWorth = rentPortfolio;
+
+    totalOwnOutlay += ownAnnualCost;
+    totalRentOutlay += rentAnnual;
+
+    rows.push({
+      year,
+      propertyValue: round(propertyValue),
+      loanBalance: round(loanBalance),
+      buyEquity: round(buyEquity),
+      ownAnnualCost: round(ownAnnualCost),
+      rentAnnual: round(rentAnnual),
+      buyInvestments: round(buyInvestments),
+      rentPortfolio: round(rentPortfolio),
+      buyNetWorth: round(buyNetWorth),
+      rentNetWorth: round(rentNetWorth),
+      netWorthGap: round(buyNetWorth - rentNetWorth),
+    });
+  }
+
+  const breakEvenRow = rows.find((r) => r.buyNetWorth >= r.rentNetWorth);
+  const last = rows[rows.length - 1];
+
+  return {
+    input,
+    loanPrincipal: round(loanPrincipal),
+    monthlyMortgage: round(monthlyMortgage),
+    upfrontCash: round(upfrontCash),
+    totalInterest: round(Math.max(0, totalInterest)),
+    priceToRent: input.monthlyRent > 0 ? round(input.price / (input.monthlyRent * 12)) : 0,
+    rows,
+    breakEvenYear: breakEvenRow ? breakEvenRow.year : null,
+    buyWins: last.buyNetWorth >= last.rentNetWorth,
+    buyNetWorthAtHorizon: last.buyNetWorth,
+    rentNetWorthAtHorizon: last.rentNetWorth,
+    totalOwnOutlay: round(totalOwnOutlay),
+    totalRentOutlay: round(totalRentOutlay),
+    mortgagePctOfIncome:
+      input.monthlyIncome > 0 ? round((monthlyMortgage / input.monthlyIncome) * 100) : null,
+  };
+}
+
+/** Deflate a nominal peso figure at `year` into today's pesos. */
+export function toRealPesos(nominal: number, year: number, inflationPct: number): number {
+  return nominal / Math.pow(1 + inflationPct / 100, year);
+}

--- a/app/rent-vs-buy/_lib/defaults.ts
+++ b/app/rent-vs-buy/_lib/defaults.ts
@@ -1,0 +1,97 @@
+import type { RentVsBuyInput } from "./types";
+
+/**
+ * Researched Philippine defaults (May 2026). Sources are documented in the
+ * /docs Rent vs. Buy section. Every value is user-editable — this is a
+ * simulator anchored to current market data, not a quote.
+ */
+export const DEFAULT_INPUT: RentVsBuyInput = {
+  // Property — sample mid-market Metro Manila condo
+  price: 5_000_000,
+  floorAreaSqm: 36,
+  appreciationPct: 4, // condo ~3.2%, house ~13% — conservative blend
+
+  // Financing — bank fixed-rate norm (Pag-IBIG presets available)
+  downPaymentPct: 20,
+  mortgageRatePct: 6.75, // BPI/BDO fixed, 2026
+  loanTermYears: 20,
+  closingCostPct: 5, // DST 1.5% + transfer ~0.75% + registration ~0.5% + professional ~2%
+
+  // Carrying costs
+  assessmentLevelPct: 20, // residential RPT assessment level
+  rptRatePct: 2, // Metro Manila max
+  sefRatePct: 1, // Special Education Fund
+  duesPerSqmMonthly: 100, // Metro Manila mid-market association dues
+  maintenancePct: 1,
+  homeInsurancePct: 0.15,
+
+  // Renting — ~5–6% gross yield on the price
+  monthlyRent: 25_000,
+  rentGrowthPct: 4,
+
+  // Economy
+  investReturnPct: 7, // Pag-IBIG MP2 7.12% tax-free floor; equities historically higher
+  costInflationPct: 3.5, // BSP 2026 forecast ~3.6%, target band 3–4%
+
+  // Horizon / exit
+  horizonYears: 10,
+  assumeSaleAtHorizon: true,
+  sellingCostPct: 9.5, // CGT 6% + broker ~3% + notarial ~0.5%
+
+  monthlyIncome: 0,
+};
+
+/** Per-field metadata for the inputs form (label, tooltip, step, unit). */
+export interface FieldMeta {
+  key: keyof RentVsBuyInput;
+  label: string;
+  tip: string;
+  step: number;
+  suffix?: string;
+}
+
+export const FIELD_GROUPS: { title: string; fields: FieldMeta[] }[] = [
+  {
+    title: "Property",
+    fields: [
+      { key: "price", label: "Purchase price", tip: "Total contract price of the home.", step: 50_000, suffix: "₱" },
+      { key: "floorAreaSqm", label: "Floor area", tip: "Used to compute association dues.", step: 1, suffix: "sqm" },
+      { key: "appreciationPct", label: "Appreciation / yr", tip: "Expected annual rise in the property's value.", step: 0.5, suffix: "%" },
+    ],
+  },
+  {
+    title: "Financing",
+    fields: [
+      { key: "downPaymentPct", label: "Down payment", tip: "Equity paid upfront; the rest is financed.", step: 1, suffix: "%" },
+      { key: "mortgageRatePct", label: "Mortgage rate / yr", tip: "Annual interest rate on the home loan.", step: 0.25, suffix: "%" },
+      { key: "loanTermYears", label: "Loan term", tip: "Years to fully amortise the loan.", step: 1, suffix: "yrs" },
+      { key: "closingCostPct", label: "Closing costs", tip: "One-time taxes & fees to transfer title (DST, transfer tax, registration, professional).", step: 0.5, suffix: "%" },
+    ],
+  },
+  {
+    title: "Carrying costs",
+    fields: [
+      { key: "duesPerSqmMonthly", label: "Assoc. dues", tip: "Condo / HOA dues per square metre per month.", step: 5, suffix: "₱/sqm/mo" },
+      { key: "rptRatePct", label: "RPT rate", tip: "Real property tax rate (Metro Manila max 2%).", step: 0.25, suffix: "%" },
+      { key: "maintenancePct", label: "Maintenance / yr", tip: "Annual upkeep as a % of property value.", step: 0.25, suffix: "%" },
+      { key: "homeInsurancePct", label: "Insurance / yr", tip: "Home / fire insurance as a % of value.", step: 0.05, suffix: "%" },
+    ],
+  },
+  {
+    title: "Renting",
+    fields: [
+      { key: "monthlyRent", label: "Monthly rent", tip: "Rent for an equivalent home today.", step: 1_000, suffix: "₱" },
+      { key: "rentGrowthPct", label: "Rent growth / yr", tip: "Annual rent escalation.", step: 0.5, suffix: "%" },
+    ],
+  },
+  {
+    title: "Economy & horizon",
+    fields: [
+      { key: "investReturnPct", label: "Investment return / yr", tip: "What you'd earn investing the cash you didn't sink into the home (MP2, UITF, equities).", step: 0.5, suffix: "%" },
+      { key: "costInflationPct", label: "Inflation / yr", tip: "General inflation for recurring costs and the real-peso view.", step: 0.5, suffix: "%" },
+      { key: "horizonYears", label: "Horizon", tip: "How many years you'll hold this decision.", step: 1, suffix: "yrs" },
+      { key: "sellingCostPct", label: "Selling cost", tip: "CGT 6% + broker ~3% + notarial, applied when you assume a sale.", step: 0.5, suffix: "%" },
+      { key: "monthlyIncome", label: "Monthly income", tip: "Optional — flags whether the mortgage is within the ~30% rule. 0 to skip.", step: 5_000, suffix: "₱" },
+    ],
+  },
+];

--- a/app/rent-vs-buy/_lib/monte-carlo.ts
+++ b/app/rent-vs-buy/_lib/monte-carlo.ts
@@ -1,0 +1,88 @@
+import { simulate } from "./compute";
+import type { MonteCarloResult, RentVsBuyInput } from "./types";
+
+/**
+ * Uncertainty around the three assumptions that matter most. Each is a +/-
+ * spread (in percentage points) applied as a symmetric triangular distribution
+ * around the user's point estimate.
+ */
+export const MC_SPREADS = {
+  appreciationPct: 3,
+  investReturnPct: 3,
+  rentGrowthPct: 2,
+} as const;
+
+/** Triangular draw in [c − s, c + s] with the mode at c (mean-reverting to the point estimate). */
+function triangular(center: number, spread: number, rnd: () => number): number {
+  // Sum of two uniforms ≈ triangular distribution centred on `center`.
+  const u = (rnd() + rnd()) / 2; // in [0, 1], peaked at 0.5
+  return center + (u * 2 - 1) * spread;
+}
+
+/** Deterministic PRNG (mulberry32) so a given scenario yields a stable result. */
+function makeRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.round((p / 100) * (sorted.length - 1))));
+  return sorted[idx];
+}
+
+/**
+ * Run many simulations with the key assumptions sampled from their uncertainty
+ * ranges. Returns the probability buying wins, the median break-even year, and
+ * P10/P50/P90 net-worth-gap bands per year for the fan chart.
+ */
+export function monteCarlo(input: RentVsBuyInput, runs = 2000): MonteCarloResult {
+  const horizon = Math.max(1, Math.round(input.horizonYears));
+  const rng = makeRng(Math.round(input.price + input.monthlyRent + input.mortgageRatePct * 1000));
+
+  let buyWins = 0;
+  let everBreakEven = 0;
+  const breakEvenYears: number[] = [];
+  const gapByYear: number[][] = Array.from({ length: horizon }, () => []);
+
+  for (let i = 0; i < runs; i++) {
+    const sample: RentVsBuyInput = {
+      ...input,
+      appreciationPct: triangular(input.appreciationPct, MC_SPREADS.appreciationPct, rng),
+      investReturnPct: triangular(input.investReturnPct, MC_SPREADS.investReturnPct, rng),
+      rentGrowthPct: triangular(input.rentGrowthPct, MC_SPREADS.rentGrowthPct, rng),
+    };
+    const r = simulate(sample);
+    if (r.buyWins) buyWins++;
+    if (r.breakEvenYear !== null) {
+      everBreakEven++;
+      breakEvenYears.push(r.breakEvenYear);
+    }
+    r.rows.forEach((row, y) => gapByYear[y].push(row.netWorthGap));
+  }
+
+  breakEvenYears.sort((a, b) => a - b);
+  const bands = gapByYear.map((gaps, y) => {
+    const sorted = [...gaps].sort((a, b) => a - b);
+    return {
+      year: y + 1,
+      p10: Math.round(percentile(sorted, 10)),
+      p50: Math.round(percentile(sorted, 50)),
+      p90: Math.round(percentile(sorted, 90)),
+    };
+  });
+
+  return {
+    runs,
+    pBuyWins: buyWins / runs,
+    pEverBreakEven: everBreakEven / runs,
+    breakEvenP50: breakEvenYears.length ? percentile(breakEvenYears, 50) : null,
+    bands,
+  };
+}

--- a/app/rent-vs-buy/_lib/presets.ts
+++ b/app/rent-vs-buy/_lib/presets.ts
@@ -1,0 +1,33 @@
+import type { RentVsBuyInput } from "./types";
+
+/**
+ * One-click Philippine financing profiles. Each overrides only the financing
+ * levers (rate, term, down payment) — grounded in 2026 Pag-IBIG and bank rates.
+ */
+export interface FinancingPreset {
+  key: string;
+  label: string;
+  note: string;
+  overrides: Partial<RentVsBuyInput>;
+}
+
+export const FINANCING_PRESETS: FinancingPreset[] = [
+  {
+    key: "pagibig-socialized",
+    label: "Pag-IBIG socialized",
+    note: "3% fixed 5 yrs · for lower-cost housing",
+    overrides: { mortgageRatePct: 3, loanTermYears: 30, downPaymentPct: 10 },
+  },
+  {
+    key: "pagibig-regular",
+    label: "Pag-IBIG regular",
+    note: "~6.25% · up to 30-yr term",
+    overrides: { mortgageRatePct: 6.25, loanTermYears: 30, downPaymentPct: 20 },
+  },
+  {
+    key: "bank-fixed",
+    label: "Bank fixed",
+    note: "~6.75% · BPI / BDO 2026",
+    overrides: { mortgageRatePct: 6.75, loanTermYears: 20, downPaymentPct: 20 },
+  },
+];

--- a/app/rent-vs-buy/_lib/solver.ts
+++ b/app/rent-vs-buy/_lib/solver.ts
@@ -1,0 +1,90 @@
+import { simulate } from "./compute";
+import type { RentVsBuyInput, SensitivityBar, SolveResult } from "./types";
+
+type NumericKey = keyof Pick<
+  RentVsBuyInput,
+  "appreciationPct" | "investReturnPct" | "monthlyRent" | "mortgageRatePct" | "downPaymentPct"
+>;
+
+/** Net-worth gap (buy − rent) at the horizon when `key` is set to `value`. */
+function gapAt(input: RentVsBuyInput, key: keyof RentVsBuyInput, value: number): number {
+  const r = simulate({ ...input, [key]: value });
+  return r.buyNetWorthAtHorizon - r.rentNetWorthAtHorizon;
+}
+
+/**
+ * Goal-seek by bisection: find the value of `key` at which buying and renting
+ * break even at the horizon (the gap crosses zero). Works for any monotone
+ * lever regardless of direction, as long as the bracket contains a sign change.
+ */
+export function solveForBreakEven(
+  input: RentVsBuyInput,
+  key: NumericKey,
+  lo: number,
+  hi: number
+): SolveResult {
+  const fLo = gapAt(input, key, lo);
+  const fHi = gapAt(input, key, hi);
+
+  if (Number.isNaN(fLo) || Number.isNaN(fHi)) {
+    return { solved: false, value: null, message: "Could not evaluate the scenario." };
+  }
+  if (fLo === 0) return { solved: true, value: lo, message: "" };
+  if (fHi === 0) return { solved: true, value: hi, message: "" };
+  if (fLo > 0 && fHi > 0) {
+    return { solved: false, value: null, message: "Buying wins across the entire range." };
+  }
+  if (fLo < 0 && fHi < 0) {
+    return { solved: false, value: null, message: "Renting wins across the entire range." };
+  }
+
+  let a = lo;
+  let b = hi;
+  let fa = fLo;
+  for (let i = 0; i < 60; i++) {
+    const mid = (a + b) / 2;
+    const fm = gapAt(input, key, mid);
+    if (Math.abs(fm) < 1 || b - a < 1e-4) {
+      return { solved: true, value: Math.round(mid * 100) / 100, message: "" };
+    }
+    if ((fa < 0 && fm < 0) || (fa > 0 && fm > 0)) {
+      a = mid;
+      fa = fm;
+    } else {
+      b = mid;
+    }
+  }
+  return { solved: true, value: Math.round(((a + b) / 2) * 100) / 100, message: "" };
+}
+
+const SENSITIVITY_FIELDS: { key: keyof RentVsBuyInput; label: string }[] = [
+  { key: "appreciationPct", label: "Property appreciation" },
+  { key: "investReturnPct", label: "Investment return" },
+  { key: "mortgageRatePct", label: "Mortgage rate" },
+  { key: "monthlyRent", label: "Monthly rent" },
+  { key: "price", label: "Property price" },
+  { key: "downPaymentPct", label: "Down payment" },
+  { key: "rentGrowthPct", label: "Rent growth" },
+];
+
+/**
+ * Tornado sensitivity: shift each lever ±20% (relative) and measure how far the
+ * net-worth gap at the horizon swings. Ranked by absolute swing — the biggest
+ * bar is the assumption the decision hinges on.
+ */
+export function sensitivity(input: RentVsBuyInput): SensitivityBar[] {
+  const bars = SENSITIVITY_FIELDS.map(({ key, label }) => {
+    const base = input[key] as number;
+    const span = base === 0 ? 1 : Math.abs(base) * 0.2;
+    const lowGap = gapAt(input, key, base - span);
+    const highGap = gapAt(input, key, base + span);
+    return {
+      key,
+      label,
+      lowGap: Math.round(lowGap),
+      highGap: Math.round(highGap),
+      swing: Math.abs(highGap - lowGap),
+    };
+  });
+  return bars.sort((a, b) => b.swing - a.swing);
+}

--- a/app/rent-vs-buy/_lib/types.ts
+++ b/app/rent-vs-buy/_lib/types.ts
@@ -1,0 +1,93 @@
+/** All user-editable inputs for the Rent vs. Buy simulation. */
+export interface RentVsBuyInput {
+  // Property
+  price: number; // PHP purchase price
+  floorAreaSqm: number;
+  appreciationPct: number; // annual property appreciation
+
+  // Financing
+  downPaymentPct: number;
+  mortgageRatePct: number; // annual nominal rate
+  loanTermYears: number;
+  closingCostPct: number; // one-time, % of price (DST + transfer + registration + professional)
+
+  // Carrying costs
+  assessmentLevelPct: number; // RPT assessment level (residential ≈ 20%)
+  rptRatePct: number; // real property tax rate (Metro Manila max 2%)
+  sefRatePct: number; // Special Education Fund (1%)
+  duesPerSqmMonthly: number; // association dues, PHP / sqm / month
+  maintenancePct: number; // annual, % of property value
+  homeInsurancePct: number; // annual, % of property value
+
+  // Renting
+  monthlyRent: number;
+  rentGrowthPct: number; // annual rent escalation
+
+  // Opportunity cost / economy
+  investReturnPct: number; // annual return on invested cash
+  costInflationPct: number; // general inflation for recurring costs + real-peso deflator
+
+  // Horizon / exit
+  horizonYears: number;
+  assumeSaleAtHorizon: boolean; // value equity net of selling costs
+  sellingCostPct: number; // CGT 6% + broker ~3% + notarial
+
+  // Optional reality checks
+  monthlyIncome: number; // 0 = not provided
+}
+
+/** One simulated year. Both net-worth figures are nominal pesos. */
+export interface YearRow {
+  year: number;
+  propertyValue: number;
+  loanBalance: number;
+  buyEquity: number; // property value − loan balance − (selling costs if assuming sale)
+  ownAnnualCost: number; // mortgage + carrying costs that year
+  rentAnnual: number;
+  buyInvestments: number; // surplus the buyer invested vs. the shared housing budget
+  rentPortfolio: number; // renter's invested portfolio
+  buyNetWorth: number; // buyEquity + buyInvestments
+  rentNetWorth: number; // rentPortfolio
+  netWorthGap: number; // buyNetWorth − rentNetWorth
+}
+
+export interface RentVsBuyResult {
+  input: RentVsBuyInput;
+  loanPrincipal: number;
+  monthlyMortgage: number;
+  upfrontCash: number; // down payment + closing costs
+  totalInterest: number; // over the full loan term
+  priceToRent: number; // price ÷ annual rent
+  rows: YearRow[];
+  breakEvenYear: number | null; // first year buy net worth ≥ rent net worth (null ⇒ renting wins)
+  buyWins: boolean; // at the horizon
+  buyNetWorthAtHorizon: number;
+  rentNetWorthAtHorizon: number;
+  totalOwnOutlay: number; // upfront + all owning out-of-pocket over horizon
+  totalRentOutlay: number; // all rent over horizon
+  mortgagePctOfIncome: number | null; // monthly mortgage ÷ monthly income
+}
+
+/** A single goal-seek (inverse) answer. */
+export interface SolveResult {
+  solved: boolean;
+  value: number | null; // the input value that flips/meets the target
+  message: string;
+}
+
+/** One bar in the sensitivity tornado. */
+export interface SensitivityBar {
+  key: keyof RentVsBuyInput;
+  label: string;
+  lowGap: number; // net-worth gap @ horizon when input is shifted down
+  highGap: number; // … shifted up
+  swing: number; // |highGap − lowGap| — used for ranking
+}
+
+export interface MonteCarloResult {
+  runs: number;
+  pBuyWins: number; // probability buy net worth ≥ rent net worth at horizon
+  breakEvenP50: number | null; // median break-even year across runs that ever break even
+  pEverBreakEven: number; // share of runs that break even within the horizon
+  bands: { year: number; p10: number; p50: number; p90: number }[]; // net-worth gap percentile bands
+}

--- a/app/rent-vs-buy/_lib/url-state.ts
+++ b/app/rent-vs-buy/_lib/url-state.ts
@@ -1,0 +1,59 @@
+import { DEFAULT_INPUT } from "./defaults";
+import type { RentVsBuyInput } from "./types";
+
+/** Compact short codes so a shared link stays readable. */
+const CODES: Record<string, keyof RentVsBuyInput> = {
+  p: "price",
+  fa: "floorAreaSqm",
+  ap: "appreciationPct",
+  dp: "downPaymentPct",
+  mr: "mortgageRatePct",
+  lt: "loanTermYears",
+  cc: "closingCostPct",
+  al: "assessmentLevelPct",
+  rp: "rptRatePct",
+  sf: "sefRatePct",
+  du: "duesPerSqmMonthly",
+  mt: "maintenancePct",
+  hi: "homeInsurancePct",
+  rn: "monthlyRent",
+  rg: "rentGrowthPct",
+  ir: "investReturnPct",
+  cf: "costInflationPct",
+  hz: "horizonYears",
+  sc: "sellingCostPct",
+  in: "monthlyIncome",
+};
+
+const FIELD_TO_CODE = Object.fromEntries(
+  Object.entries(CODES).map(([code, field]) => [field, code])
+) as Record<keyof RentVsBuyInput, string>;
+
+/** Encode inputs into a query string (only values that differ from defaults). */
+export function encodeInput(input: RentVsBuyInput): string {
+  const params = new URLSearchParams();
+  for (const [code, field] of Object.entries(CODES)) {
+    const value = input[field] as number;
+    if (value !== (DEFAULT_INPUT[field] as number)) params.set(code, String(value));
+  }
+  if (input.assumeSaleAtHorizon !== DEFAULT_INPUT.assumeSaleAtHorizon) {
+    params.set("sl", input.assumeSaleAtHorizon ? "1" : "0");
+  }
+  return params.toString();
+}
+
+/** Rebuild a full input from a query string, falling back to defaults. */
+export function decodeInput(params: URLSearchParams): RentVsBuyInput {
+  const input: RentVsBuyInput = { ...DEFAULT_INPUT };
+  for (const [code, field] of Object.entries(CODES)) {
+    const raw = params.get(code);
+    if (raw === null) continue;
+    const num = Number(raw);
+    if (Number.isFinite(num)) (input[field] as number) = num;
+  }
+  const sl = params.get("sl");
+  if (sl !== null) input.assumeSaleAtHorizon = sl === "1";
+  return input;
+}
+
+export { FIELD_TO_CODE };

--- a/app/rent-vs-buy/_lib/url-state.ts
+++ b/app/rent-vs-buy/_lib/url-state.ts
@@ -25,10 +25,6 @@ const CODES: Record<string, keyof RentVsBuyInput> = {
   in: "monthlyIncome",
 };
 
-const FIELD_TO_CODE = Object.fromEntries(
-  Object.entries(CODES).map(([code, field]) => [field, code])
-) as Record<keyof RentVsBuyInput, string>;
-
 /** Encode inputs into a query string (only values that differ from defaults). */
 export function encodeInput(input: RentVsBuyInput): string {
   const params = new URLSearchParams();
@@ -55,5 +51,3 @@ export function decodeInput(params: URLSearchParams): RentVsBuyInput {
   if (sl !== null) input.assumeSaleAtHorizon = sl === "1";
   return input;
 }
-
-export { FIELD_TO_CODE };

--- a/app/rent-vs-buy/layout.tsx
+++ b/app/rent-vs-buy/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { JsonLd } from "@/components/json-ld";
+import { breadcrumbLd, buildToolMetadata } from "@/app/_lib/seo";
+
+export const metadata: Metadata = buildToolMetadata({
+  title: "Rent vs. Buy a Home",
+  description:
+    "Should you buy a condo or keep renting and invest the difference? A year-by-year wealth simulation for the Philippines — mortgage, amilyar, dues, appreciation — with the break-even year and the probability buying wins.",
+  path: "/rent-vs-buy",
+  keywords: [
+    "rent vs buy calculator philippines",
+    "should i buy a condo philippines",
+    "rent or buy house philippines",
+    "condo investment calculator philippines",
+    "break even rent vs buy",
+    "mortgage vs rent philippines",
+  ],
+});
+
+export default function RentVsBuyLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <JsonLd
+        data={breadcrumbLd([
+          { name: "Home", path: "/" },
+          { name: "Rent vs. Buy a Home", path: "/rent-vs-buy" },
+        ])}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/rent-vs-buy/page.tsx
+++ b/app/rent-vs-buy/page.tsx
@@ -18,6 +18,7 @@ import { GoalSeekCard } from "./_components/goal-seek-card";
 import { PriceToRentGauge } from "./_components/price-to-rent-gauge";
 import { YearlyTable } from "./_components/yearly-table";
 import { AssumptionsCard } from "./_components/assumptions-card";
+import { ToolHeader } from "@/app/_components/tool-header";
 
 const RentVsBuy: React.FC = () => {
   const router = useRouter();
@@ -87,19 +88,10 @@ const RentVsBuy: React.FC = () => {
 const RentVsBuyPage: React.FC = () => {
   return (
     <main className="max-w-7xl mx-auto px-4 py-6 sm:py-8">
-      <div className="mb-8 max-w-3xl">
-        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-2">
-          Tool
-        </p>
-        <h1 className="font-display font-extralight text-3xl sm:text-4xl lg:text-5xl tracking-[-0.03em]">
-          Rent vs. Buy a Home
-        </h1>
-        <p className="mt-3 text-sm sm:text-base text-muted-foreground leading-relaxed">
-          Should you buy that condo or keep renting and invest the difference? This runs a year-by-year
-          wealth simulation — mortgage, amilyar, dues, appreciation, and the opportunity cost of your
-          down payment — then tells you the break-even year and the probability buying actually wins.
-        </p>
-      </div>
+      <ToolHeader
+        title="Rent vs. Buy a Home"
+        description="Should you buy that condo or keep renting and invest the difference? This runs a year-by-year wealth simulation — mortgage, amilyar, dues, appreciation, and the opportunity cost of your down payment — then tells you the break-even year and the probability buying actually wins."
+      />
 
       <Suspense
         fallback={

--- a/app/rent-vs-buy/page.tsx
+++ b/app/rent-vs-buy/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { simulate } from "./_lib/compute";
+import { monteCarlo } from "./_lib/monte-carlo";
+import { sensitivity } from "./_lib/solver";
+import { DEFAULT_INPUT } from "./_lib/defaults";
+import { decodeInput, encodeInput } from "./_lib/url-state";
+import type { RentVsBuyInput } from "./_lib/types";
+import { InputsForm } from "./_components/inputs-form";
+import { FinancingPresets } from "./_components/financing-presets";
+import { ShareBar } from "./_components/share-bar";
+import { ResultSummary } from "./_components/result-summary";
+import { BreakevenChart } from "./_components/breakeven-chart";
+import { SensitivityTornado } from "./_components/sensitivity-tornado";
+import { GoalSeekCard } from "./_components/goal-seek-card";
+import { PriceToRentGauge } from "./_components/price-to-rent-gauge";
+import { YearlyTable } from "./_components/yearly-table";
+import { AssumptionsCard } from "./_components/assumptions-card";
+
+function RentVsBuy() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [input, setInput] = useState<RentVsBuyInput>(() => decodeInput(searchParams));
+  const [realPesos, setRealPesos] = useState(false);
+
+  // Keep the URL in sync so the scenario is shareable / reloadable.
+  useEffect(() => {
+    const query = encodeInput(input);
+    router.replace(query ? `?${query}` : window.location.pathname, { scroll: false });
+  }, [input, router]);
+
+  const onChange = useCallback(
+    <K extends keyof RentVsBuyInput>(key: K, value: RentVsBuyInput[K]) =>
+      setInput((prev) => ({ ...prev, [key]: value })),
+    []
+  );
+  const applyPreset = useCallback(
+    (overrides: Partial<RentVsBuyInput>) => setInput((prev) => ({ ...prev, ...overrides })),
+    []
+  );
+
+  const result = useMemo(() => simulate(input), [input]);
+  const mc = useMemo(() => monteCarlo(input), [input]);
+  const bars = useMemo(() => sensitivity(input), [input]);
+
+  return (
+    <div className="grid lg:grid-cols-[300px_1fr] gap-6 lg:gap-10">
+        <aside className="lg:sticky lg:top-20 lg:self-start space-y-5">
+          <FinancingPresets input={input} onApply={applyPreset} />
+          <InputsForm
+            input={input}
+            onChange={onChange}
+            realPesos={realPesos}
+            setRealPesos={setRealPesos}
+          />
+          <AssumptionsCard />
+        </aside>
+
+        <section className="min-w-0 space-y-5">
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <p className="font-mono-label text-[10px] uppercase tracking-[0.2em] text-muted-foreground opacity-60">
+              Results {realPesos ? "· today's pesos" : "· nominal pesos"}
+            </p>
+            <ShareBar input={input} onReset={() => setInput(DEFAULT_INPUT)} />
+          </div>
+
+          <ResultSummary result={result} mc={mc} realPesos={realPesos} />
+
+          <div className="grid md:grid-cols-2 gap-5">
+            <PriceToRentGauge ratio={result.priceToRent} />
+            <SensitivityTornado bars={bars} />
+          </div>
+
+          <BreakevenChart result={result} mc={mc} realPesos={realPesos} />
+
+          <GoalSeekCard input={input} />
+
+          <YearlyTable result={result} realPesos={realPesos} />
+        </section>
+    </div>
+  );
+}
+
+export default function RentVsBuyPage() {
+  return (
+    <main className="max-w-7xl mx-auto px-4 py-6 sm:py-8">
+      <div className="mb-8 max-w-3xl">
+        <p className="font-mono-label text-[10px] uppercase tracking-[0.25em] text-muted-foreground opacity-60 mb-2">
+          Tool
+        </p>
+        <h1 className="font-display font-extralight text-3xl sm:text-4xl lg:text-5xl tracking-[-0.03em]">
+          Rent vs. Buy a Home
+        </h1>
+        <p className="mt-3 text-sm sm:text-base text-muted-foreground leading-relaxed">
+          Should you buy that condo or keep renting and invest the difference? This runs a year-by-year
+          wealth simulation — mortgage, amilyar, dues, appreciation, and the opportunity cost of your
+          down payment — then tells you the break-even year and the probability buying actually wins.
+        </p>
+      </div>
+
+      <Suspense
+        fallback={
+          <div className="py-10 text-sm text-muted-foreground">Loading simulator…</div>
+        }
+      >
+        <RentVsBuy />
+      </Suspense>
+    </main>
+  );
+}

--- a/app/rent-vs-buy/page.tsx
+++ b/app/rent-vs-buy/page.tsx
@@ -19,7 +19,7 @@ import { PriceToRentGauge } from "./_components/price-to-rent-gauge";
 import { YearlyTable } from "./_components/yearly-table";
 import { AssumptionsCard } from "./_components/assumptions-card";
 
-function RentVsBuy() {
+const RentVsBuy: React.FC = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -82,9 +82,9 @@ function RentVsBuy() {
         </section>
     </div>
   );
-}
+};
 
-export default function RentVsBuyPage() {
+const RentVsBuyPage: React.FC = () => {
   return (
     <main className="max-w-7xl mx-auto px-4 py-6 sm:py-8">
       <div className="mb-8 max-w-3xl">
@@ -110,4 +110,6 @@ export default function RentVsBuyPage() {
       </Suspense>
     </main>
   );
-}
+};
+
+export default RentVsBuyPage;

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,4 +1,5 @@
 import { MetadataRoute } from "next";
+import { SITE_URL } from "@/app/_lib/seo";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -6,5 +7,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: "*",
       allow: "/",
     },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,16 @@
+import { MetadataRoute } from "next";
+import { SITE_URL } from "@/app/_lib/seo";
+import { SECONDARY_LINKS, TOOLS, type LiveTool } from "@/app/_lib/tools";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  const livePaths = TOOLS.filter((t): t is LiveTool => t.status === "live").map((t) => t.href);
+  const paths = ["/", ...livePaths, ...SECONDARY_LINKS.map((l) => l.href)];
+
+  return paths.map((path) => ({
+    url: `${SITE_URL}${path === "/" ? "" : path}`,
+    lastModified: now,
+    changeFrequency: "monthly",
+    priority: path === "/" ? 1 : 0.8,
+  }));
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,4 +1,7 @@
 import Link from "next/link";
+import { TOOLS, SECONDARY_LINKS, type LiveTool } from "@/app/_lib/tools";
+
+const LIVE_TOOLS = TOOLS.filter((tool): tool is LiveTool => tool.status === "live");
 
 const Footer: React.FC = () => {
   return (
@@ -12,7 +15,8 @@ const Footer: React.FC = () => {
           <div>
             <h3 className="font-display font-light text-lg mb-3">Savvy Spender</h3>
             <p className="text-muted-foreground text-xs leading-relaxed">
-              A focused installment calculator built for Filipino consumers. More tools coming soon.
+              Free, open-source financial tools built for Filipino consumers — installments, card
+              forex, car financing, freelancer payouts, and rent vs. buy.
             </p>
           </div>
 
@@ -22,24 +26,20 @@ const Footer: React.FC = () => {
               Explore
             </h3>
             <ul className="space-y-1.5 text-xs">
-              <li>
-                <Link href="/calculator" className="text-muted-foreground hover:text-foreground transition-colors">
-                  Installment Calculator
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/bank-conversion-list"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  Bank Conversion List
-                </Link>
-              </li>
-              <li>
-                <Link href="/docs" className="text-muted-foreground hover:text-foreground transition-colors">
-                  Documentation
-                </Link>
-              </li>
+              {LIVE_TOOLS.map((tool) => (
+                <li key={tool.href}>
+                  <Link href={tool.href} className="text-muted-foreground hover:text-foreground transition-colors">
+                    {tool.title}
+                  </Link>
+                </li>
+              ))}
+              {SECONDARY_LINKS.map((link) => (
+                <li key={link.href}>
+                  <Link href={link.href} className="text-muted-foreground hover:text-foreground transition-colors">
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
             </ul>
           </div>
 

--- a/components/json-ld.tsx
+++ b/components/json-ld.tsx
@@ -1,0 +1,13 @@
+/**
+ * Embeds a JSON-LD structured-data block. Server-safe — render it anywhere in a
+ * page (including inside Client Component pages) and it ships in the SSR HTML.
+ */
+export const JsonLd: React.FC<{ data: object }> = ({ data }) => {
+  return (
+    <script
+      type="application/ld+json"
+      // Structured data is build-time/server constant; no user input.
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+};

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,31 +3,36 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Moon, Sun, Menu, Calculator, BookOpen, Building2, Github } from "lucide-react";
+import { Moon, Sun, Menu, Github, ChevronDown } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
+import { TOOLS, SECONDARY_LINKS, type LiveTool } from "@/app/_lib/tools";
 
-const NAV_LINKS = [
-  { href: "/calculator", label: "Calculator", icon: Calculator },
-  { href: "/docs", label: "Docs", icon: BookOpen },
-  { href: "/bank-conversion-list", label: "Banks", icon: Building2 },
-];
+const LIVE_TOOLS = TOOLS.filter((tool): tool is LiveTool => tool.status === "live");
 
 const Navbar: React.FC = () => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(false); // mobile sheet
+  const [toolsOpen, setToolsOpen] = useState(false); // desktop dropdown
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const { theme, setTheme } = useTheme();
   const pathname = usePathname();
 
-  const toggleColorMode = () => {
-    setTheme(theme === "light" ? "dark" : "light");
-  };
+  // Close the desktop dropdown on outside click and on navigation.
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) setToolsOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, []);
+  useEffect(() => setToolsOpen(false), [pathname]);
 
-  const isActive = (href: string) =>
-    pathname === href || (href !== "/" && pathname.startsWith(href));
+  const toggleColorMode = () => setTheme(theme === "light" ? "dark" : "light");
+  const isActive = (href: string) => pathname === href || (href !== "/" && pathname.startsWith(href));
 
   return (
     <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -39,15 +44,50 @@ const Navbar: React.FC = () => {
 
         {/* Desktop navigation */}
         <div className="hidden md:flex items-center gap-1">
-          {NAV_LINKS.map((link) => (
+          <div className="relative" ref={dropdownRef}>
+            <button
+              type="button"
+              onClick={() => setToolsOpen((o) => !o)}
+              aria-expanded={toolsOpen}
+              className={cn(
+                "flex items-center gap-1 font-mono-label text-[10px] uppercase tracking-[0.15em] px-3 py-2 rounded-sm transition-colors",
+                LIVE_TOOLS.some((t) => isActive(t.href))
+                  ? "text-foreground"
+                  : "text-muted-foreground opacity-60 hover:opacity-100"
+              )}
+            >
+              Tools
+              <ChevronDown className={cn("h-3 w-3 transition-transform", toolsOpen && "rotate-180")} />
+            </button>
+            {toolsOpen && (
+              <div className="absolute left-0 top-full mt-1 w-72 rounded-md border bg-popover p-1 shadow-md z-50">
+                {LIVE_TOOLS.map((tool) => (
+                  <Link
+                    key={tool.href}
+                    href={tool.href}
+                    onClick={() => setToolsOpen(false)}
+                    className={cn(
+                      "flex items-start gap-2.5 rounded-sm px-2.5 py-2 transition-colors hover:bg-accent",
+                      isActive(tool.href) && "bg-accent"
+                    )}
+                  >
+                    <tool.icon className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0">
+                      <span className="block text-xs font-medium">{tool.title}</span>
+                      <span className="block text-[10px] text-muted-foreground truncate">{tool.meta}</span>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+          {SECONDARY_LINKS.map((link) => (
             <Link
               key={link.href}
               href={link.href}
               className={cn(
                 "font-mono-label text-[10px] uppercase tracking-[0.15em] px-3 py-2 rounded-sm transition-colors",
-                isActive(link.href)
-                  ? "text-foreground"
-                  : "text-muted-foreground opacity-60 hover:opacity-100"
+                isActive(link.href) ? "text-foreground" : "text-muted-foreground opacity-60 hover:opacity-100"
               )}
             >
               {link.label}
@@ -73,11 +113,7 @@ const Navbar: React.FC = () => {
             aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
             onClick={toggleColorMode}
           >
-            {theme === "light" ? (
-              <Moon className="h-4 w-4" />
-            ) : (
-              <Sun className="h-4 w-4" />
-            )}
+            {theme === "light" ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
           </Button>
 
           {/* Mobile menu */}
@@ -91,12 +127,33 @@ const Navbar: React.FC = () => {
               <SheetContent>
                 <SheetHeader>
                   <SheetTitle className="font-display font-light text-xl">Navigate</SheetTitle>
-                  <SheetDescription>
-                    Calculator, banks, and documentation.
-                  </SheetDescription>
+                  <SheetDescription>All tools, banks, and documentation.</SheetDescription>
                 </SheetHeader>
                 <div className="grid gap-1 py-4">
-                  {NAV_LINKS.map((link) => (
+                  <p className="px-3 pt-2 pb-1 font-mono-label text-[9px] uppercase tracking-[0.2em] text-muted-foreground opacity-60">
+                    Tools
+                  </p>
+                  {LIVE_TOOLS.map((tool) => (
+                    <Button
+                      key={tool.href}
+                      variant="ghost"
+                      className={cn(
+                        "justify-start font-mono-label text-[11px] uppercase tracking-[0.1em]",
+                        isActive(tool.href) && "text-foreground bg-accent"
+                      )}
+                      onClick={() => setOpen(false)}
+                      asChild
+                    >
+                      <Link href={tool.href}>
+                        <tool.icon className="mr-2 h-3.5 w-3.5" />
+                        {tool.title}
+                      </Link>
+                    </Button>
+                  ))}
+                  <p className="px-3 pt-3 pb-1 font-mono-label text-[9px] uppercase tracking-[0.2em] text-muted-foreground opacity-60">
+                    More
+                  </p>
+                  {SECONDARY_LINKS.map((link) => (
                     <Button
                       key={link.href}
                       variant="ghost"

--- a/components/ui/collapsible.tsx
+++ b/components/ui/collapsible.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface CollapsibleProps {
+  title: React.ReactNode;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/** Minimal disclosure (no Radix dependency) for help / glossary sections. */
+export const Collapsible: React.FC<CollapsibleProps> = ({
+  title,
+  defaultOpen = false,
+  children,
+  className,
+}) => {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-2 text-left"
+      >
+        {title}
+        <ChevronDown
+          className={cn("h-4 w-4 shrink-0 text-muted-foreground transition-transform", open && "rotate-180")}
+        />
+      </button>
+      {open && <div className="mt-3">{children}</div>}
+    </div>
+  );
+};

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -1,0 +1,22 @@
+/** Quote a CSV cell when it contains a comma, quote, or newline. */
+function escapeCell(value: string | number): string {
+  const s = String(value);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+/**
+ * Build a CSV string from a header row + data rows and trigger a client-side
+ * download. No dependency — uses a Blob + object URL.
+ */
+export function downloadCsv(filename: string, header: string[], rows: (string | number)[][]): void {
+  const lines = [header, ...rows].map((row) => row.map(escapeCell).join(","));
+  const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename.endsWith(".csv") ? filename : `${filename}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/lib/use-query-state.ts
+++ b/lib/use-query-state.ts
@@ -32,6 +32,7 @@ export function decodeState<T extends Record<string, Primitive>>(
     if (raw === null) return;
     const def = defaults[key];
     if (typeof def === "number") {
+      if (raw.trim() === "") return; // empty string would coerce to 0
       const n = Number(raw);
       if (Number.isFinite(n)) out[key] = n as T[keyof T];
     } else if (typeof def === "boolean") {
@@ -58,7 +59,16 @@ export function useQueryState<T extends Record<string, Primitive>>(
   const [state, setState] = useState<T>(() => decodeState(searchParams, defaults, codes));
 
   useEffect(() => {
-    const query = encodeState(state, defaults, codes);
+    // Merge managed keys onto the existing query so unrelated params (utm_*, etc.)
+    // are preserved rather than stripped on mount.
+    const params = new URLSearchParams(searchParams.toString());
+    (Object.keys(codes) as (keyof T)[]).forEach((key) => {
+      const value = state[key];
+      const code = codes[key];
+      if (value === defaults[key]) params.delete(code);
+      else params.set(code, typeof value === "boolean" ? (value ? "1" : "0") : String(value));
+    });
+    const query = params.toString();
     router.replace(query ? `?${query}` : window.location.pathname, { scroll: false });
     // defaults & codes are module-level constants; only `state` drives updates.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/lib/use-query-state.ts
+++ b/lib/use-query-state.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+type Primitive = number | boolean | string;
+
+/** Serialize state into a query string, omitting values equal to the defaults. */
+export function encodeState<T extends Record<string, Primitive>>(
+  state: T,
+  defaults: T,
+  codes: Record<keyof T, string>
+): string {
+  const params = new URLSearchParams();
+  (Object.keys(codes) as (keyof T)[]).forEach((key) => {
+    const value = state[key];
+    if (value === defaults[key]) return;
+    params.set(codes[key], typeof value === "boolean" ? (value ? "1" : "0") : String(value));
+  });
+  return params.toString();
+}
+
+/** Rebuild typed state from a query string, coercing by the default's type. */
+export function decodeState<T extends Record<string, Primitive>>(
+  params: URLSearchParams,
+  defaults: T,
+  codes: Record<keyof T, string>
+): T {
+  const out: T = { ...defaults };
+  (Object.keys(codes) as (keyof T)[]).forEach((key) => {
+    const raw = params.get(codes[key]);
+    if (raw === null) return;
+    const def = defaults[key];
+    if (typeof def === "number") {
+      const n = Number(raw);
+      if (Number.isFinite(n)) out[key] = n as T[keyof T];
+    } else if (typeof def === "boolean") {
+      out[key] = (raw === "1") as T[keyof T];
+    } else {
+      out[key] = raw as T[keyof T];
+    }
+  });
+  return out;
+}
+
+/**
+ * Typed state that round-trips through the URL query string, so any scenario is
+ * shareable / reloadable with no backend. `codes` maps each field to a short
+ * query key; `defaults` defines both the initial state and the value types.
+ * Must be used inside a <Suspense> boundary (uses useSearchParams).
+ */
+export function useQueryState<T extends Record<string, Primitive>>(
+  defaults: T,
+  codes: Record<keyof T, string>
+): [T, (patch: Partial<T>) => void, () => void] {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [state, setState] = useState<T>(() => decodeState(searchParams, defaults, codes));
+
+  useEffect(() => {
+    const query = encodeState(state, defaults, codes);
+    router.replace(query ? `?${query}` : window.location.pathname, { scroll: false });
+    // defaults & codes are module-level constants; only `state` drives updates.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
+
+  const patch = useCallback((p: Partial<T>) => setState((prev) => ({ ...prev, ...p })), []);
+  const reset = useCallback(() => setState({ ...defaults }), [defaults]);
+
+  return [state, patch, reset];
+}


### PR DESCRIPTION
Year-by-year wealth simulation comparing owning (mortgage amortization,
amilyar/RPT, dues, appreciation, equity) against renting and investing the
difference. Headline output is the break-even year where buying overtakes
renting in net worth.

Standout features beyond a basic calculator:
- Monte-Carlo "probability buying wins" with P10/P50/P90 net-worth bands
- Goal-seek solver (bisection) for the appreciation/return/rent that flips it
- Sensitivity tornado ranking which assumption drives the verdict
- One-click PH financing presets (Pag-IBIG socialized/regular, bank fixed)
- Shareable scenario links via URL-encoded state (no backend)
- Price-to-rent gauge, inflation-adjusted toggle, affordability guardrail

Defaults anchored to researched May 2026 Philippine figures. Client-side
only (useMemo recompute), no new dependencies. Registered in the tool
registry and documented in /docs.